### PR TITLE
Added delegate call mechanism for contracts to swap using meta-aggregator without approval.

### DIFF
--- a/contracts/meta-aggregator/MetaAggregatorSwapContract.sol
+++ b/contracts/meta-aggregator/MetaAggregatorSwapContract.sol
@@ -8,62 +8,90 @@ import {TransferHelper} from "./libraries/TransferHelper.sol";
 
 /**
  * @title MetaAggregatorSwapContract
- * @dev This contract facilitates swapping between ETH and ERC20 tokens using an aggregator.
+ * @dev Facilitates swapping between ETH and ERC20 tokens or between two ERC20 tokens using an aggregator.
  */
 contract MetaAggregatorSwapContract is
     ReentrancyGuard,
     IMetaAggregatorSwapContract
 {
-    address constant nativeToken = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-    address immutable usdt;
-    address immutable SWAP_TARGET;
+    address constant nativeToken = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE; // Represent native ETH token
+    address immutable usdt; // Address of USDT token
+    address immutable SWAP_TARGET; // Address of the swap target for delegatecall operations
+    address immutable _this; // Address of this contract instance
 
-    // Custom error definitions
+    // Custom error messages for efficient error handling
     error CannotSwapTokens();
     error AmountInMustBeGreaterThanZero();
     error MinAmountOutMustBeGreaterThanZero();
     error TokenInAndTokenOutCannotBeSame();
     error IncorrectEtherAmountSent();
     error CannotSwapETHToETH();
-    error InsufficientOutputBalance();
-    error InsufficientTokenInBalance();
-    error InsufficientETHOutAmount();
-    error InsufficientTokenOutAmount();
-    error SwapFailed();
     error InvalidReceiver();
     error InvalidENSOAddress();
     error InvalidUSDTAddress();
+    error InsufficientOutputBalance();
+    error InsufficientETHOutAmount();
+    error InsufficientTokenOutAmount();
+    error SwapFailed();
+    error NotDelegate();
+    error CannotSwapETH();
 
-    event AmountSent(uint256 indexed amount, address indexed tokenOut);
+    //   Event emitted when ETH is swapped for an ERC20 token
+    event ETHSwappedForToken(
+        uint256 indexed amountOut,
+        address indexed tokenOut,
+        address indexed receiver
+    );
+
+    // Event emitted when an ERC20 token is swapped for another ERC20 token
+    event ERC20Swapped(
+        uint256 indexed amountOut,
+        address indexed tokenIn,
+        address indexed tokenOut,
+        address receiver
+    );
+
+    // Event emitted when ETH is swapped using delegatecall
+    event ETHSwappedDelegate(
+        uint256 indexed amountOut,
+        address indexed tokenOut,
+        address indexed receiver
+    );
+
+    // Event emitted when an ERC20 token is swapped using delegatecall
+    event ERC20SwappedDelegate(
+        uint256 indexed amountOut,
+        address indexed tokenIn,
+        address indexed tokenOut,
+        address receiver
+    );
 
     /**
-     * @dev Sets the swap target address.
+     * @dev Initializes the contract with the swap target and USDT addresses.
      * @param _ensoSwapContract The address of the swap target contract.
+     * @param _usdt The address of the USDT token.
      */
     constructor(address _ensoSwapContract, address _usdt) {
-        if(_ensoSwapContract == address(0)) {
-            revert InvalidENSOAddress();
-        }
-        if(_usdt == address(0)) {
-            revert InvalidUSDTAddress();
-        }
+        if (_ensoSwapContract == address(0)) revert InvalidENSOAddress();
+        if (_usdt == address(0)) revert InvalidUSDTAddress();
         SWAP_TARGET = _ensoSwapContract;
         usdt = _usdt;
+        _this = address(this);
     }
 
     /**
      * @dev Swaps ETH for an ERC20 token.
-     * @param tokenIn The input token (must be ETH).
-     * @param tokenOut The output token (ERC20).
-     * @param aggregator The address of the aggregator to perform the swap.
+     * @param tokenIn must be the native token.
+     * @param tokenOut The ERC20 token to swap to.
+     * @param aggregator The address of the aggregator to use for the swap.
      * @param swapData The data required for the swap.
      * @param amountIn The amount of ETH to swap.
      * @param minAmountOut The minimum amount of tokenOut expected.
-     * @param receiver The address to receive the output tokens.
-     * @param isDelegate Whether to use delegatecall for the swap.
+     * @param receiver The address to receive the tokenOut.
+     * @param isDelegate Indicates if the swap is in a delegatecall context.
      */
     function swapETH(
-        IERC20 tokenIn,
+        address tokenIn,
         IERC20 tokenOut,
         address aggregator,
         bytes calldata swapData,
@@ -72,9 +100,7 @@ contract MetaAggregatorSwapContract is
         address receiver,
         bool isDelegate
     ) external payable nonReentrant {
-        if (address(tokenIn) != nativeToken) {
-            revert CannotSwapTokens();
-        }
+        if (address(tokenIn) != nativeToken) revert CannotSwapTokens();
         uint256 amountOut = _swapETH(
             tokenIn,
             tokenOut,
@@ -85,20 +111,24 @@ contract MetaAggregatorSwapContract is
             receiver,
             isDelegate
         );
-
-        emit AmountSent(amountOut, address(tokenOut));
+        emit ERC20Swapped(
+            amountOut,
+            address(tokenIn),
+            address(tokenOut),
+            receiver
+        );
     }
 
     /**
-     * @dev Swaps one ERC20 token for another. Should be called from manager contract through swap function.
-     * @param tokenIn The input token (ERC20).
-     * @param tokenOut The output token (ERC20) or Native token (ETH).
-     * @param aggregator The address of the aggregator to perform the swap.
+     * @dev Swaps one ERC20 token for another ERC20 token or native ETH.
+     * @param tokenIn The ERC20 token to swap from.
+     * @param tokenOut The ERC20 token to swap to or native ETH.
+     * @param aggregator The address of the aggregator to use for the swap.
      * @param swapData The data required for the swap.
      * @param amountIn The amount of tokenIn to swap.
      * @param minAmountOut The minimum amount of tokenOut expected.
-     * @param receiver The address to receive the output tokens.
-     * @param isDelegate Whether to use delegatecall for the swap.
+     * @param receiver The address to receive the tokenOut.
+     * @param isDelegate Indicates if the swap is in a delegatecall context.
      */
     function swapERC20(
         IERC20 tokenIn,
@@ -120,23 +150,68 @@ contract MetaAggregatorSwapContract is
             receiver,
             isDelegate
         );
-
-        emit AmountSent(amountOut, address(tokenOut));
+        emit ETHSwappedForToken(amountOut, address(tokenOut), receiver);
     }
 
     /**
-     * @dev Internal function to perform the swap logic.
-     * @param tokenIn The input token (ETH).
-     * @param tokenOut The output token (ERC20).
-     * @param aggregator The address of the aggregator to perform the swap.
+     * @dev Swaps ETH using delegatecall.
+     * This function is called when the swap needs to happen in a delegatecall context.
+     * @param tokenIn must be the native token.
+     * @param tokenOut The ERC20 token to swap to.
+     * @param aggregator The address of the aggregator to use for the swap.
+     * @param swapData The data required for the swap.
+     * @param amountIn The amount of ETH to swap.
+     * @param minAmountOut The minimum amount of tokenOut expected.
+     * @param receiver The address to receive the tokenOut.
+     * @param isDelegate Indicates if the swap is in a delegatecall context.
+     * @return amountOut The amount of tokenOut received.
+     */
+    function swapETHDelegate(
+        address tokenIn,
+        IERC20 tokenOut,
+        address aggregator,
+        bytes calldata swapData,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver,
+        bool isDelegate
+    ) external payable returns (uint256 amountOut) {
+        if (address(this) == _this) revert NotDelegate();
+        if (tokenIn != nativeToken) revert CannotSwapTokens();
+
+        _validateInputs(
+            tokenIn,
+            address(tokenOut),
+            amountIn,
+            minAmountOut,
+            receiver
+        );
+        if (msg.value != amountIn) revert IncorrectEtherAmountSent();
+
+        uint256 balanceBefore = tokenOut.balanceOf(address(this));
+        _executeAggregatorCall(swapData, isDelegate, aggregator, amountIn);
+        amountOut = tokenOut.balanceOf(address(this)) - balanceBefore;
+        if (amountOut < minAmountOut) revert InsufficientOutputBalance();
+        if (receiver != address(this))
+            TransferHelper.safeTransfer(address(tokenOut), receiver, amountOut);
+
+        emit ETHSwappedDelegate(amountOut, address(tokenOut), receiver);
+    }
+
+    /**
+     * @dev Swaps ERC20 tokens using delegatecall.
+     * This function is called when the swap needs to happen in a delegatecall context.
+     * @param tokenIn The ERC20 token to swap from.
+     * @param tokenOut The ERC20 token to swap to or native ETH.
+     * @param aggregator The address of the aggregator to use for the swap.
      * @param swapData The data required for the swap.
      * @param amountIn The amount of tokenIn to swap.
      * @param minAmountOut The minimum amount of tokenOut expected.
-     * @param receiver The address to receive the output tokens.
-     * @param isDelegate Whether to use delegatecall for the swap.
+     * @param receiver The address to receive the tokenOut.
+     * @param isDelegate Indicates if the swap is in a delegatecall context.
      * @return amountOut The amount of tokenOut received.
      */
-    function _swapETH(
+    function swapERC20Delegate(
         IERC20 tokenIn,
         IERC20 tokenOut,
         address aggregator,
@@ -145,49 +220,106 @@ contract MetaAggregatorSwapContract is
         uint256 minAmountOut,
         address receiver,
         bool isDelegate
-    ) internal returns (uint256 amountOut) {
-        if (receiver == address(0)) {
-            revert InvalidReceiver();
-        }
-        if (amountIn == 0) {
-            revert AmountInMustBeGreaterThanZero();
-        }
-        if (minAmountOut == 0) {
-            revert MinAmountOutMustBeGreaterThanZero();
-        }
-        if (address(tokenIn) == address(tokenOut)) {
-            revert TokenInAndTokenOutCannotBeSame();
-        }
+    ) external returns (uint256 amountOut) {
+        if (address(this) == _this) revert NotDelegate();
+        if (address(tokenIn) == nativeToken) revert CannotSwapETH();
 
-        if (msg.value != amountIn) {
-            revert IncorrectEtherAmountSent();
-        }
+        _validateInputs(
+            address(tokenIn),
+            address(tokenOut),
+            amountIn,
+            minAmountOut,
+            receiver
+        );
 
-        uint256 balanceBeforeSwap = tokenOut.balanceOf(address(this)); // Get the balance after the swap
-
-        _callAggregator(swapData, isDelegate, aggregator);
-
-        uint256 balanceAfterSwap = tokenOut.balanceOf(address(this));
-
-        amountOut = balanceAfterSwap - balanceBeforeSwap;
-        if (amountOut < minAmountOut) {
-            revert InsufficientOutputBalance();
+        if (!isDelegate) {
+            if (address(tokenIn) == usdt)
+                TransferHelper.safeApprove(address(tokenIn), aggregator, 0);
+            TransferHelper.safeApprove(address(tokenIn), aggregator, amountIn);
         }
 
-        TransferHelper.safeTransfer(address(tokenOut), receiver, amountOut);
+        // If tokenOut is native
+        if (address(tokenOut) == nativeToken) {
+            uint256 balanceBefore = address(this).balance;
+            _executeAggregatorCall(swapData, isDelegate, aggregator, 0);
+            amountOut = address(this).balance - balanceBefore;
+            if (amountOut < minAmountOut) revert InsufficientETHOutAmount();
+            if (receiver != address(this)) {
+                (bool success, ) = receiver.call{value: amountOut}("");
+                if (!success) revert SwapFailed();
+            }
+        } else {
+            uint256 balanceBefore = tokenOut.balanceOf(address(this));
+            _executeAggregatorCall(swapData, isDelegate, aggregator, 0);
+            amountOut = tokenOut.balanceOf(address(this)) - balanceBefore;
+            if (amountOut < minAmountOut) revert InsufficientTokenOutAmount();
+            if (receiver != address(this))
+                TransferHelper.safeTransfer(
+                    address(tokenOut),
+                    receiver,
+                    amountOut
+                );
+        }
+
+        emit ERC20SwappedDelegate(
+            amountOut,
+            address(tokenIn),
+            address(tokenOut),
+            receiver
+        );
     }
 
     /**
-     * @dev Internal function to perform the swap logic.
-     * @param tokenIn The input token (ERC20).
-     * @param tokenOut The output token (ERC20 or ETH).
-     * @param aggregator The address of the aggregator to perform the swap.
+     * @dev Internal function to perform the swap from ETH to ERC20.
+     * @param tokenIn must be the native token.
+     * @param tokenOut The ERC20 token to swap to.
+     * @param aggregator The address of the aggregator to use for the swap.
+     * @param swapData The data required for the swap.
+     * @param amountIn The amount of ETH to swap.
+     * @param minAmountOut The minimum amount of tokenOut expected.
+     * @param receiver The address to receive the tokenOut.
+     * @param isDelegate Indicates if the swap is in a delegatecall context.
+     * @return The amount of tokenOut received.
+     */
+    function _swapETH(
+        address tokenIn,
+        IERC20 tokenOut,
+        address aggregator,
+        bytes calldata swapData,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver,
+        bool isDelegate
+    ) internal returns (uint256) {
+        _validateInputs(
+            tokenIn,
+            address(tokenOut),
+            amountIn,
+            minAmountOut,
+            receiver
+        );
+        if (msg.value != amountIn) revert IncorrectEtherAmountSent();
+
+        uint256 balanceBefore = tokenOut.balanceOf(address(this));
+        _executeAggregatorCall(swapData, isDelegate, aggregator, amountIn);
+        uint256 amountOut = tokenOut.balanceOf(address(this)) - balanceBefore;
+
+        if (amountOut < minAmountOut) revert InsufficientOutputBalance();
+        TransferHelper.safeTransfer(address(tokenOut), receiver, amountOut);
+        return amountOut;
+    }
+
+    /**
+     * @dev Internal function to swap ERC20 tokens or ERC20 to native ETH.
+     * @param tokenIn The ERC20 token to swap from.
+     * @param tokenOut The ERC20 token to swap to or native ETH.
+     * @param aggregator The address of the aggregator to use for the swap.
      * @param swapData The data required for the swap.
      * @param amountIn The amount of tokenIn to swap.
      * @param minAmountOut The minimum amount of tokenOut expected.
-     * @param receiver The address to receive the output tokens.
-     * @param isDelegate Whether to use delegatecall for the swap.
-     * @return amountOut The amount of tokenOut received.
+     * @param receiver The address to receive the tokenOut.
+     * @param isDelegate Indicates if the swap is in a delegatecall context.
+     * @return The amount of tokenOut received.
      */
     function _swapERC20(
         IERC20 tokenIn,
@@ -198,102 +330,90 @@ contract MetaAggregatorSwapContract is
         uint256 minAmountOut,
         address receiver,
         bool isDelegate
-    ) internal returns (uint256 amountOut) {
-        if (receiver == address(0)) {
-            revert InvalidReceiver();
-        }
-        if (amountIn == 0) {
-            revert AmountInMustBeGreaterThanZero();
-        }
-        if (minAmountOut == 0) {
-            revert MinAmountOutMustBeGreaterThanZero();
-        }
-        if (address(tokenIn) == address(tokenOut)) {
-            revert TokenInAndTokenOutCannotBeSame();
+    ) internal returns (uint256) {
+        _validateInputs(
+            address(tokenIn),
+            address(tokenOut),
+            amountIn,
+            minAmountOut,
+            receiver
+        );
+
+        if (!isDelegate) {
+            if (address(tokenIn) == usdt)
+                TransferHelper.safeApprove(address(tokenIn), aggregator, 0);
+            TransferHelper.safeApprove(address(tokenIn), aggregator, amountIn);
         }
 
-        if(address(tokenIn) == usdt)TransferHelper.safeApprove(address(tokenIn), aggregator, 0);
-        TransferHelper.safeApprove(address(tokenIn), aggregator, amountIn);
-
-        // Check if tokenOut is native
+        uint256 amountOut;
         if (address(tokenOut) == nativeToken) {
-            uint256 balanceBeforeSwap = address(this).balance; // Get the balance after the swap
+            uint256 balanceBefore = address(this).balance;
+            _executeAggregatorCall(swapData, isDelegate, aggregator, 0);
+            amountOut = address(this).balance - balanceBefore;
+            if (amountOut < minAmountOut) revert InsufficientETHOutAmount();
 
-            _callAggregator(swapData, isDelegate, aggregator);
-
-            uint256 balanceAfterSwap = address(this).balance;
-
-            amountOut = balanceAfterSwap - balanceBeforeSwap;
-            if (amountOut < minAmountOut) {
-                revert InsufficientETHOutAmount();
-            }
-
-            if (receiver.code.length > 0) {
-                // Use call to send ETH to the contract
-                (bool success, bytes memory returnData) = receiver.call{
-                    value: amountOut
-                }("");
-                if (!success) {
-                    assembly {
-                        let returnData_size := mload(returnData)
-                        revert(add(32, returnData), returnData_size)
-                    }
-                }
-            } else {
-                // Use transfer to send ETH to the EOA
-                payable(receiver).transfer(amountOut);
-            }
+            (bool success, ) = receiver.call{value: amountOut}("");
+            if (!success) revert SwapFailed();
         } else {
-            uint256 balanceBeforeSwap = tokenOut.balanceOf(address(this)); // Get the balance after the swap
+            uint256 balanceBefore = tokenOut.balanceOf(address(this));
+            _executeAggregatorCall(swapData, isDelegate, aggregator, 0);
+            amountOut = tokenOut.balanceOf(address(this)) - balanceBefore;
+            if (amountOut < minAmountOut) revert InsufficientTokenOutAmount();
 
-            _callAggregator(swapData, isDelegate, aggregator);
-
-            uint256 balanceAfterSwap = tokenOut.balanceOf(address(this));
-
-            amountOut = balanceAfterSwap - balanceBeforeSwap;
-            if (amountOut < minAmountOut) {
-                revert InsufficientTokenOutAmount();
-            }
             TransferHelper.safeTransfer(address(tokenOut), receiver, amountOut);
         }
+
+        return amountOut;
     }
 
     /**
-     * @dev Internal function to call the aggregator for the swap.
+     * @dev Executes a swap call via the aggregator or delegatecall context.
      * @param swapData The data required for the swap.
-     * @param isDelegate Whether to use delegatecall for the swap.
-     * @param aggregator The address of the aggregator to perform the swap.
+     * @param isDelegate Indicates if the swap is in a delegatecall context.
+     * @param aggregator The address of the aggregator to use for the swap.
+     * @param value The amount of ETH to send with the call (if applicable).
      */
-    function _callAggregator(
+    function _executeAggregatorCall(
         bytes memory swapData,
         bool isDelegate,
-        address aggregator
+        address aggregator,
+        uint256 value
     ) internal {
-        if (!isDelegate) {
-            (bool success, bytes memory returnData) = aggregator.call{
-                value: msg.value
-            }(swapData);
-            if (!success) {
-                assembly {
-                    let returnData_size := mload(returnData)
-                    revert(add(32, returnData), returnData_size)
-                }
-            }
-        } else {
-            (bool success, bytes memory returnData) = SWAP_TARGET.delegatecall(
-                swapData
-            );
-            if (!success) {
-                assembly {
-                    let returnData_size := mload(returnData)
-                    revert(add(32, returnData), returnData_size)
-                }
+        (bool success, bytes memory returnData) = isDelegate
+            ? SWAP_TARGET.delegatecall(swapData)
+            : aggregator.call{value: value}(swapData);
+
+        if (!success) {
+            assembly {
+                let size := mload(returnData)
+                revert(add(32, returnData), size)
             }
         }
     }
 
     /**
-     * @dev Fallback function to receive ETH.
+     * @dev Validates the swap inputs for consistency and correctness.
+     * @param tokenIn address of tokenIn
+     * @param tokenOut address of tokenIn
+     * @param amountIn The amount of tokenIn to swap.
+     * @param minAmountOut The minimum amount of tokenOut expected.
+     * @param receiver The address to receive the tokenOut.
+     */
+    function _validateInputs(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver
+    ) internal pure {
+        if (receiver == address(0)) revert InvalidReceiver();
+        if (amountIn == 0) revert AmountInMustBeGreaterThanZero();
+        if (minAmountOut == 0) revert MinAmountOutMustBeGreaterThanZero();
+        if (tokenIn == tokenOut) revert TokenInAndTokenOutCannotBeSame();
+    }
+
+    /**
+     * @dev Allows the contract to receive ETH.
      */
     receive() external payable {}
 }

--- a/contracts/meta-aggregator/MetaAggregatorSwapContract.sol
+++ b/contracts/meta-aggregator/MetaAggregatorSwapContract.sol
@@ -101,14 +101,6 @@ contract MetaAggregatorSwapContract is IMetaAggregatorSwapContract {
     }
 
     /**
-     * @dev Returns true if the reentrancy guard is currently set to "entered", which indicates there is a
-     * `nonReentrant` function in the call stack.
-     */
-    function _reentrancyGuardEntered() internal view returns (bool) {
-        return _status == _ENTERED;
-    }
-
-    /**
      * @dev Swaps ETH for an ERC20 token.
      * @param tokenIn must be the native token.
      * @param tokenOut The ERC20 token to swap to.

--- a/contracts/meta-aggregator/README.md
+++ b/contracts/meta-aggregator/README.md
@@ -16,12 +16,11 @@ The MetaAggregator Contracts are a set of Solidity smart contracts designed to f
 #### Functions
 
 - `constructor(address _metaAggregatorSwap)`: Initializes the contract with the address of the `MetaAggregatorSwapContract`.
-- `swap(IERC20 tokenIn, IERC20 tokenOut, address aggregator, bytes calldata swapData, uint256 amountIn, uint256 minAmountOut, address receiver, bool isDelegate)`: Swaps tokens using the specified aggregator.
+- `swap(IERC20 tokenIn, IERC20 tokenOut, address aggregator, bytes calldata swapData, uint256 amountIn, uint256 minAmountOut, address receiver, bool isDelegate)`: Swaps tokens using the specified aggregator. This method is to be used by EOAs preferably.
 
 ### 2. MetaAggregatorSwapContract
 
-- **Purpose**: Facilitates the token swaps between ETH and ERC20 tokens.
-- **Key Features**:
+- **Purpose**: Facilitates the token swaps between ETH and ERC20 tokens. For ERC20 swaps are preferably to be done by Contracts.
   - Handles both ETH and ERC20 token inputs.
   - Allows for delegate calls to external aggregators for swaps.
 
@@ -34,13 +33,13 @@ The architecture of the MetaAggregator Contracts consists of two main components
    - **Key Responsibilities**:
      - Validate user inputs and ensure that the correct tokens are being swapped.
      - Transfer the specified amount of input tokens from the user to the `MetaAggregatorSwapContract`.
-     - Call the appropriate swap function on the `MetaAggregatorSwapContract` to perform the actual token swap for ERC20 tokens.
+     - Call the appropriate swap function on the `MetaAggregatorSwapContract` to perform the actual token swap for ERC20 tokens For EOAs.
      - Emit events to notify listeners of successful swaps.
 
 2. **MetaAggregatorSwapContract**:
    - This contract is responsible for executing the actual token swaps, including both ERC20 tokens and ETH. It interacts with external aggregators to facilitate the swaps.
    - **Key Responsibilities**:
-     - Handle both ETH and ERC20 token inputs for swaps.
+     - Handle both ETH and ERC20 token inputs for swaps.For ERC20 swaps are to be done by Contracts preferably.
      - Execute the swap logic, which may involve calling external aggregators to perform the actual token swap.
      - Transfer the output tokens to the specified receiver address after the swap is completed.
      - Emit events to notify listeners of successful swaps.
@@ -48,7 +47,9 @@ The architecture of the MetaAggregator Contracts consists of two main components
 #### Functions
 
 - `swapETH(...)`: Swaps ETH for an ERC20 token.
-- `swapERC20(...)`: Swaps one ERC20 token for another. Is called from the Manager contact.
+- `swapERC20(...)`: Swaps one ERC20 token for another. Is called from the Manager contract.
+- `swapETHDelegate(...)`: Swaps ETH for an ERC20 token using delegate call. This method is intended to be called by other contracts and does not require prior approval.
+- `swapERC20Delegate(...)`: Swaps one ERC20 token for another using delegate call. This method is intended to be called by other contracts and does not require prior approval.
 - `_swap(...)`: Internal function that contains the logic for performing swaps.
 - `_callAggregator(...)`: Internal function to call the aggregator for the swap.
 

--- a/contracts/meta-aggregator/README.md
+++ b/contracts/meta-aggregator/README.md
@@ -48,8 +48,6 @@ The architecture of the MetaAggregator Contracts consists of two main components
 
 - `swapETH(...)`: Swaps ETH for an ERC20 token.
 - `swapERC20(...)`: Swaps one ERC20 token for another. Is called from the Manager contract.
-- `swapETHDelegate(...)`: Swaps ETH for an ERC20 token using delegate call. This method is intended to be called by other contracts and does not require prior approval.
-- `swapERC20Delegate(...)`: Swaps one ERC20 token for another using delegate call. This method is intended to be called by other contracts and does not require prior approval.
 - `_swap(...)`: Internal function that contains the logic for performing swaps.
 - `_callAggregator(...)`: Internal function to call the aggregator for the swap.
 

--- a/contracts/meta-aggregator/interfaces/IMetaAggregatorSwapContract.sol
+++ b/contracts/meta-aggregator/interfaces/IMetaAggregatorSwapContract.sol
@@ -16,7 +16,7 @@ interface IMetaAggregatorSwapContract {
     ) external;
 
     function swapETH(
-        IERC20 tokenIn,
+        address tokenIn,
         IERC20 tokenOut,
         address aggregator,
         bytes calldata swapData,

--- a/contracts/meta-aggregator/test/NonReentrantTest.sol
+++ b/contracts/meta-aggregator/test/NonReentrantTest.sol
@@ -29,7 +29,7 @@ contract NonReentrantTest {
 
     function receiverCallETH(
         address callerAddress,
-        IERC20 tokenIn,
+        address tokenIn,
         IERC20 tokenOut,
         address aggregator,
         bytes calldata swapData,

--- a/contracts/meta-aggregator/test/ReceiverContract.sol
+++ b/contracts/meta-aggregator/test/ReceiverContract.sol
@@ -4,28 +4,24 @@ pragma solidity 0.8.17;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../interfaces/IMetaAggregatorManager.sol";
 
-
 contract ReceiverContract {
     uint256 public data;
 
-    receive() external payable {
-        // Arbitrary logic to consume more than 2300 gas
-        for (uint256 i = 0; i < 200; i++) {
-            data += i; // Simple computation to increase gas cost
-        }
-    }
-
-      /**
+    /**
      * @dev Approves a specified amount of tokens for a spender.
      * @param token The address of the ERC20 token contract.
      * @param spender The address that will be allowed to spend the tokens.
      * @param amount The amount of tokens to approve.
      */
-    function approveTokens(address token, address spender, uint256 amount) external {
+    function approveTokens(
+        address token,
+        address spender,
+        uint256 amount
+    ) external {
         IERC20(token).approve(spender, amount);
     }
 
-      /**
+    /**
      * @dev Calls the swap function in the TestManagerContract.
      * @param testManager The address of the TestManagerContract.
      * @param tokenIn The address of the input token.
@@ -44,6 +40,32 @@ contract ReceiverContract {
         address receiver,
         bool isDelegate
     ) external {
-        IMetaAggregatorManager(testManager).swap(tokenIn, tokenOut, aggregator, swapData, amountIn, minAmountOut, receiver, isDelegate);
+        IMetaAggregatorManager(testManager).swap(
+            tokenIn,
+            tokenOut,
+            aggregator,
+            swapData,
+            amountIn,
+            minAmountOut,
+            receiver,
+            isDelegate
+        );
     }
+
+    /**
+     * @dev Function to call the swapETHDelegate function on the MetaAggregatorSwapContract using delegatecall.
+     * @param swapData swapdata for swapping on MetaAggregatorSwapContract
+     */
+    function executeDelegate(
+        address metaAggregatorSwapContract,
+        bytes calldata swapData
+    ) external payable {
+        (bool success, bytes memory data) = metaAggregatorSwapContract
+            .delegatecall(swapData);
+
+        require(success, "ETH swap failed");
+        // Optionally, you can handle the returned data (amountOut) here
+    }
+
+    receive() external payable {}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@uniswap/v2-periphery": "^1.1.0-beta.0",
         "@uniswap/v3-core": "^1.0.1",
         "@uniswap/v3-periphery": "^1.4.4",
+        "axios": "^1.7.9",
         "chai-bignumber": "^3.0.0",
         "eslint": "8.10.0",
         "eslint-config-prettier": "^8.5.0",
@@ -4799,9 +4800,9 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "version": "1.7.9",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
+      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:arb": "CHAIN_ID=42161 hardhat test test/Arbitrum",
     "test:bsc": "CHAIN_ID=56 hardhat test test/Bsc",
     "test:meta-aggregator": "npx hardhat test test/meta-aggregator-test/*test.*",
+    "test:meta-aggregator-integration": "npx hardhat test test/meta-aggregator-integration-test-base/*test.* --vvv",
     "coverage:meta-aggregator": "npx hardhat coverage --sources meta-aggregator  --testfiles \"test/meta-aggregator-test/*test.*\"",
     "deploy:meta-aggregator": "npx hardhat run scripts/deployMetaAggregator.ts --network BaseMainnet"
   },
@@ -103,6 +104,7 @@
     "@uniswap/v2-periphery": "^1.1.0-beta.0",
     "@uniswap/v3-core": "^1.0.1",
     "@uniswap/v3-periphery": "^1.4.4",
+    "axios": "^1.7.9",
     "chai-bignumber": "^3.0.0",
     "eslint": "8.10.0",
     "eslint-config-prettier": "^8.5.0",

--- a/test/meta-aggregator-integration-test-base/fixture.ts
+++ b/test/meta-aggregator-integration-test-base/fixture.ts
@@ -1,0 +1,64 @@
+import { ethers } from "hardhat";
+import hre from "hardhat"
+
+
+// test setup
+export const setupTest = async () => {
+    const [deployer, executor, user, receiver] = await ethers.getSigners(); // Get signers
+
+    const ensoAggregator = "0x38147794FF247e5Fc179eDbAE6C37fff88f68C52"
+    const usdt = "0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2"
+
+
+
+    // Deploy MetaAggregatorTestSwapContract
+    const MetaAggregatorTestSwapContract = await ethers.getContractFactory("MetaAggregatorSwapContract");
+    const metaAggregatorTestSwapContract = await MetaAggregatorTestSwapContract.deploy(ensoAggregator, usdt);
+    await metaAggregatorTestSwapContract.deployed();
+
+    // Deploy MetaAggregatorManager
+    const MetaAggregatorManager = await ethers.getContractFactory("MetaAggregatorManager");
+    const metaAggregatorTestManager = await MetaAggregatorManager.deploy(metaAggregatorTestSwapContract.address);
+    await metaAggregatorTestManager.deployed();
+    // Deploy ReceiverContract
+    const ReceiverContract = await ethers.getContractFactory("ReceiverContract");
+    const receiverContract = await ReceiverContract.deploy();
+    await receiverContract.deployed();
+
+    // Deploy ReceiverRevert
+    const ReceiverRevert = await ethers.getContractFactory("ReceiverRevert");
+    const receiverRevert = await ReceiverRevert.deploy();
+    await receiverRevert.deployed();
+
+    const nativeToken = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+    const zeroAddress = "0x0000000000000000000000000000000000000000";
+
+    const impersonatedAccount = "0x8941516DbF170712458758FBE244D9Fd73C81B7C";
+
+
+    await hre.network.provider.request({
+        method: "hardhat_impersonateAccount",
+        params: [impersonatedAccount],
+    });
+
+    const tokenProvider = await ethers.getSigner(impersonatedAccount);
+
+
+    console.log("*******************************test setup completed*******************************");
+
+
+
+    return {
+        metaAggregatorTestManager,
+        metaAggregatorTestSwapContract,
+        nativeToken,
+        deployer,
+        executor,
+        user,
+        receiver,
+        receiverContract,
+        receiverRevert,
+        zeroAddress,
+        tokenProvider
+    };
+};

--- a/test/meta-aggregator-integration-test-base/integration-test.test.ts
+++ b/test/meta-aggregator-integration-test-base/integration-test.test.ts
@@ -1,0 +1,351 @@
+import BigNumber from "bignumber.js";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { setupTest } from "./fixture";
+import { createMetaAggregatorCalldata } from "./utils"
+import { network } from "hardhat"; // Add this line
+
+const ERC20_ABI = [
+    "function name() view returns (string)",
+    "function symbol() view returns (string)",
+    "function decimals() view returns (uint8)",
+    "function totalSupply() view returns (uint256)",
+    "function balanceOf(address owner) view returns (uint256)",
+    "function transfer(address to, uint256 amount) returns (bool)",
+];
+
+describe("Integration Swap test", function () {
+    this.timeout(600000); 
+    beforeEach(async () => {
+        await network.provider.request({
+            method: "hardhat_reset",
+            params: [
+                {
+                    forking: {
+                        jsonRpcUrl: process.env.BASE_RPC
+                    },
+                },
+            ],
+        });
+        const forkingConfig = (network.config as any).forking;
+
+        if (forkingConfig && forkingConfig.enabled) {
+            console.log("The network is forked!");
+            console.log("Forked from:", forkingConfig.url);
+
+            if (forkingConfig.blockNumber) {
+                console.log("Forked at block number:", forkingConfig.blockNumber);
+            } else {
+                console.log("Block number not specified, using the latest block.");
+            }
+        } else {
+            console.log("This network is not forked.");
+        }
+    });
+
+    it("Swap ETH to aBasWETH", async () => {
+        const { user, nativeToken, receiverContract } = await setupTest();
+
+
+        const aBasWETH = "0xd4a0e0b9149bcee3c920d2e00b5de09138fd8bb7"
+
+
+        const ETHAmount = ethers.utils.parseEther("0.000001");
+        const response = await createMetaAggregatorCalldata(receiverContract.address, user.address, nativeToken, aBasWETH, Number(ETHAmount))
+
+
+
+
+        const aBasWETHContract = new ethers.Contract(aBasWETH, ERC20_ABI, ethers.provider);
+
+        const aBaseWETHBalanceBefore = await aBasWETHContract.balanceOf(user.address);
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ", { value: ETHAmount })
+
+        const aBaseWETHBalanceAfter = await aBasWETHContract.balanceOf(user.address);
+
+        expect(aBaseWETHBalanceAfter).to.be.greaterThan(aBaseWETHBalanceBefore)
+
+        ;
+    })
+
+    it("Swap ETH to aBaseUSDC", async () => {
+        const { metaAggregatorTestSwapContract, user, nativeToken, receiverContract } = await setupTest();
+
+
+        const aBaseUSDC = "0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB"
+
+
+        const ETHAmount = ethers.utils.parseEther("0.000001");
+        const response = await createMetaAggregatorCalldata(receiverContract.address, user.address, nativeToken, aBaseUSDC, Number(ETHAmount))
+
+
+
+        const aBaseUSDCContract = new ethers.Contract(aBaseUSDC, ERC20_ABI, ethers.provider);
+
+
+        const aBaseWETHBalanceBefore = await aBaseUSDCContract.balanceOf(user.address);
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ", { value: ETHAmount })
+
+        const aBaseWETHBalanceAfter = await aBaseUSDCContract.balanceOf(user.address);
+
+        expect(aBaseWETHBalanceAfter).to.be.greaterThan(aBaseWETHBalanceBefore)
+
+        
+    })
+
+    it("Swap ETH to aBaswstETH", async () => {
+        const { metaAggregatorTestSwapContract, user, nativeToken, receiverContract } = await setupTest();
+
+
+        const aBaswstETH = "0x99CBC45ea5bb7eF3a5BC08FB1B7E56bB2442Ef0D"
+
+
+        const ETHAmount = ethers.utils.parseEther("0.000001");
+        const response = await createMetaAggregatorCalldata(receiverContract.address, user.address, nativeToken, aBaswstETH, Number(ETHAmount))
+
+
+
+        const aBaswstETHContract = new ethers.Contract(aBaswstETH, ERC20_ABI, ethers.provider);
+
+
+        const aBaswstETHBalanceBefore = await aBaswstETHContract.balanceOf(user.address);
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ", { value: ETHAmount })
+
+        const aBaswstETHBalanceAfter = await aBaswstETHContract.balanceOf(user.address);
+
+        expect(aBaswstETHBalanceAfter).to.be.greaterThan(aBaswstETHBalanceBefore)
+        
+    })
+    it("Swap ETH to usdc", async () => {
+        const { metaAggregatorTestSwapContract, user, nativeToken, receiverContract } = await setupTest();
+
+
+        const usdc = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+        const ETHAmount = 2000000000000000;
+        const response = await createMetaAggregatorCalldata(receiverContract.address, user.address, nativeToken, usdc, Number(ETHAmount))
+
+
+
+        const usdcContract = new ethers.Contract(usdc, ERC20_ABI, ethers.provider);
+
+
+        const usdcBalanceBefore = await usdcContract.balanceOf(user.address);
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ", { value: ETHAmount })
+
+        const usdcBalanceAfter = await usdcContract.balanceOf(user.address);
+
+        expect(usdcBalanceAfter).to.be.greaterThan(usdcBalanceBefore)
+        
+    })
+
+    it("Swap ETH to DAI", async () => {
+        const { user, nativeToken, receiverContract } = await setupTest();
+
+
+        const dai = "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"
+
+
+        const ETHAmount = 2000000000000000;
+        const response = await createMetaAggregatorCalldata(receiverContract.address, user.address, nativeToken, dai, Number(ETHAmount))
+
+
+
+        const daiContract = new ethers.Contract(dai, ERC20_ABI, ethers.provider);
+
+
+        const daiBalanceBefore = await daiContract.balanceOf(user.address);
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ", { value: ETHAmount })
+
+        const daiBalanceAfter = await daiContract.balanceOf(user.address);
+
+        expect(daiBalanceAfter).to.be.greaterThan(daiBalanceBefore)
+        
+    })
+
+
+
+    it("Swap dai  to  usdc", async () => {
+        const { user, nativeToken, receiverContract } = await setupTest();
+
+
+
+        const dai = "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"
+
+
+        const ETHAmount = "100000000000000000";
+        let response = await createMetaAggregatorCalldata(receiverContract.address, receiverContract.address, nativeToken, dai,ETHAmount)
+
+
+
+
+        const daiContract = new ethers.Contract(dai, ERC20_ABI, ethers.provider);
+
+
+        const daiBalanceBefore = await daiContract.balanceOf(receiverContract.address);
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ", { value: ETHAmount })
+
+        console.log("**********************************************************************************************************************************")
+        console.log("*********************************************first swap complete********************************************************************")
+        console.log("**********************************************************************************************************************************")
+
+
+        const daiBalanceAfter = await daiContract.balanceOf(receiverContract.address);
+
+        expect(daiBalanceAfter).to.be.greaterThan(daiBalanceBefore)
+
+
+        const usdc = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+
+
+        const usdcContract = new ethers.Contract(usdc, ERC20_ABI, ethers.provider);
+
+        //32.358521172381315000
+
+
+
+        const usdcBalanceBefore = await usdcContract.balanceOf(user.address);
+
+
+        response = await createMetaAggregatorCalldata(receiverContract.address, user.address, dai, usdc, "32358521172381315000")
+
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ")
+
+
+
+        const usdcBalanceAfter = await usdcContract.balanceOf(user.address);
+
+        expect(usdcBalanceAfter).to.be.greaterThan(usdcBalanceBefore)
+
+        
+    })
+
+
+
+    it("Swap cbBTC to DAI", async () => {
+        const { user, nativeToken, receiverContract } = await setupTest();
+
+
+
+        const cbBTC = "0xcbB7C0000aB88B473b1f5aFd9ef808440eed33Bf"
+
+
+        const ETHAmount = "100000000000000000";
+        let response = await createMetaAggregatorCalldata(receiverContract.address, receiverContract.address, nativeToken, cbBTC, ETHAmount)
+
+
+
+
+        const cbBTCContract = new ethers.Contract(cbBTC, ERC20_ABI, ethers.provider);
+
+
+        const cbBTCBalanceBefore = await cbBTCContract.balanceOf(receiverContract.address);
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ", { value: ETHAmount })
+
+        console.log("**********************************************************************************************************************************")
+        console.log("*********************************************first swap complete********************************************************************")
+        console.log("**********************************************************************************************************************************")
+
+
+        const cbBTCBalanceAfter = await cbBTCContract.balanceOf(receiverContract.address);
+
+        expect(cbBTCBalanceAfter).to.be.greaterThan(cbBTCBalanceBefore)
+
+
+        const dai = "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"
+
+
+        const daiContract = new ethers.Contract(dai, ERC20_ABI, ethers.provider);
+
+
+
+        const daiBalanceBefore = await daiContract.balanceOf(user.address);
+
+
+        response = await createMetaAggregatorCalldata(receiverContract.address, user.address, cbBTC, dai, 178747)
+
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ")
+
+
+
+        const daiBalanceAfter = await daiContract.balanceOf(user.address);
+
+        expect(daiBalanceAfter).to.be.greaterThan(daiBalanceBefore)
+        
+    })
+
+
+    it("Swap WETH to DAI", async () => {
+        const { user, nativeToken, receiverContract } = await setupTest();
+
+
+
+        const weth = "0x4200000000000000000000000000000000000006"
+
+
+        const ETHAmount = "100304170629935680";
+        let response = await createMetaAggregatorCalldata(receiverContract.address, receiverContract.address, nativeToken, weth, Number(ETHAmount))
+
+
+
+
+        const wethContract = new ethers.Contract(weth, ERC20_ABI, ethers.provider);
+
+
+        const wethBalanceBefore = await wethContract.balanceOf(receiverContract.address);
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ", { value: ETHAmount })
+
+        console.log("**********************************************************************************************************************************")
+        console.log("*********************************************first swap complete********************************************************************")
+        console.log("**********************************************************************************************************************************")
+
+        const wethBalanceAfter = await wethContract.balanceOf(receiverContract.address);
+
+        expect(wethBalanceAfter).to.be.greaterThan(wethBalanceBefore)
+
+
+        const dai = "0x50c5725949A6F0c72E6C4a641F24049A917DB0Cb"
+
+
+        const daiContract = new ethers.Contract(dai, ERC20_ABI, ethers.provider);
+
+
+
+        const daiBalanceBefore = await daiContract.balanceOf(user.address);
+
+
+        response = await createMetaAggregatorCalldata(receiverContract.address, user.address, weth, dai, "100304170629935680")
+
+
+        await receiverContract.connect(user).executeDelegate(response.quotes[0].to
+            , response.quotes[0].data || " ")
+
+
+
+        const daiBalanceAfter = await daiContract.balanceOf(user.address);
+
+        expect(daiBalanceAfter).to.be.greaterThan(daiBalanceBefore)
+        
+    })
+});

--- a/test/meta-aggregator-integration-test-base/utils.ts
+++ b/test/meta-aggregator-integration-test-base/utils.ts
@@ -1,0 +1,54 @@
+import axios from "axios";
+
+
+export async function createMetaAggregatorCalldata(
+    handler: string,
+    receiver: string,
+    _tokenIn: any,
+    _tokenOut: any,
+    _amountIn: any
+): Promise<any> {
+    
+    try {
+        const priceParams = {
+            slippage: 10,
+            amount: _amountIn,
+            tokenIn: _tokenIn,
+            tokenOut: _tokenOut,
+            sender: handler,
+            receiver: receiver,
+            chainId: 8453,
+            skipSimulation: true,
+        };
+
+        console.log(priceParams)
+
+        const postUrl = "http://arbitrumcentral.velvetdao.xyz:3000/best-quotes";
+
+        const response = await axios.post(postUrl, priceParams);
+        return response.data;
+    } catch (error) {
+        // Check if the error is an AxiosError
+        if (axios.isAxiosError(error)) {
+            console.error("Axios error occurred!");
+
+            // Extract useful information
+            if (error.response) {
+                // Server responded with a status code outside the 2xx range
+                console.error("Response Status:", error.response.status);
+                console.error("Response Data:", error.response.data);
+                console.error("Response Headers:", error.response.headers);
+            } else if (error.request) {
+                // Request was made but no response was received
+                console.error("No response received:", error.request);
+            } else {
+                // Other errors, like setting up the request
+                console.error("Error Message:", error.message);
+            }
+        } else {
+            // Non-Axios error
+            console.error("An unexpected error occurred:", error);
+        }
+    }
+}
+

--- a/test/meta-aggregator-test/fixture.ts
+++ b/test/meta-aggregator-test/fixture.ts
@@ -4,13 +4,16 @@ import { ethers } from "hardhat";
 // test setup
 export const setupTest = async () => {
     const [deployer, executor, user, receiver] = await ethers.getSigners(); // Get signers
-    const usdt = '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2';
 
 
     // Deploy Token1
     const Token1 = await ethers.getContractFactory("TESTERC20");
     const token1 = await Token1.deploy("Token1", "T1");
     await token1.deployed();
+
+    const usdtToken = await ethers.getContractFactory("TESTERC20");
+    const usdt = await usdtToken.deploy("USDT","usdt");
+    await usdt.deployed();
 
     // Deploy Token2
     const Token2 = await ethers.getContractFactory("TESTERC20");
@@ -34,7 +37,7 @@ export const setupTest = async () => {
 
     // Deploy MetaAggregatorTestSwapContract
     const MetaAggregatorTestSwapContract = await ethers.getContractFactory("MetaAggregatorSwapContract");
-    const metaAggregatorTestSwapContract = await MetaAggregatorTestSwapContract.deploy(ensoAggregator.address, usdt);
+    const metaAggregatorTestSwapContract = await MetaAggregatorTestSwapContract.deploy(ensoAggregator.address, usdt.address);
     await metaAggregatorTestSwapContract.deployed();
 
     // Deploy MetaAggregatorManager

--- a/test/meta-aggregator-test/meta-aggregator.test.ts
+++ b/test/meta-aggregator-test/meta-aggregator.test.ts
@@ -2,9 +2,9 @@ import BigNumber from "bignumber.js";
 import { expect } from "chai";
 import { ethers } from "hardhat";
 import { setupTest } from "./fixture";
-import{
+import {
     loadFixture,
-  } from "@nomicfoundation/hardhat-network-helpers";
+} from "@nomicfoundation/hardhat-network-helpers";
 
 describe("Swap test", function () {
     it("Swap tokens to tokens", async () => {
@@ -38,6 +38,154 @@ describe("Swap test", function () {
         expect(userToken2Balance).to.be.equal(token2Amount);
         const userToken1Balance = await token1.balanceOf(user.address);
         expect(userToken1Balance).to.be.equal(0);
+        const aggregatorToken1Balance = await token1.balanceOf(aggregator.address);
+        expect(aggregatorToken1Balance).to.be.equal(token1Amount);
+        const aggregatorToken2Balance = await token2.balanceOf(aggregator.address);
+        expect(aggregatorToken2Balance).to.be.equal(0);
+    })
+    it("Swap usdt to tokens", async () => {
+        const { usdt, token2, aggregator, metaAggregatorTestManager, user } = await loadFixture(setupTest);
+
+        const usdtAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await usdt.mint(user.address, usdtAmount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const balanceUserUSDT = await usdt.balanceOf(user.address);
+        expect(balanceUserUSDT).to.be.equal(usdtAmount);
+        const balanceAggregatorToken2 = await token2.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken2).to.be.equal(token2Amount);
+        const balanceUserToken2 = await token2.balanceOf(user.address);
+        expect(balanceUserToken2).to.be.equal(0);
+        const balanceAggregatorUSDT = await usdt.balanceOf(aggregator.address);
+        expect(balanceAggregatorUSDT).to.be.equal(0)
+
+        const swapData = await aggregator.populateTransaction.swap(usdt.address, token2.address, usdtAmount, token2Amount);
+
+        const tnx = await usdt.connect(user).approve(metaAggregatorTestManager.address, usdtAmount)
+        await tnx.wait();
+
+        await metaAggregatorTestManager.connect(user).swap(usdt.address, token2.address, aggregator.address, swapData.data || "", usdtAmount, token2Amount, user.address, false)
+
+
+        const userToken2Balance = await token2.balanceOf(user.address)
+        expect(userToken2Balance).to.be.equal(token2Amount);
+        const userUSDTBalance = await usdt.balanceOf(user.address);
+        expect(userUSDTBalance).to.be.equal(0);
+        const aggregatorUSDTBalance = await usdt.balanceOf(aggregator.address);
+        expect(aggregatorUSDTBalance).to.be.equal(usdtAmount);
+        const aggregatorToken2Balance = await token2.balanceOf(aggregator.address);
+        expect(aggregatorToken2Balance).to.be.equal(0);
+    })
+    it("Swap tokens to tokens through delegate call", async () => {
+        const { token1, token2, aggregator, user, receiverContract, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
+
+        const token1Amount = 100000000;
+        const token2Amount = 100000000;
+
+        await token1.mint(receiverContract.address, token1Amount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const balanceOfReceiverContractToken1 = await token1.balanceOf(receiverContract.address);
+        expect(balanceOfReceiverContractToken1).to.be.equal(token1Amount);
+        const balanceAggregatorToken2 = await token2.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken2).to.be.equal(token2Amount);
+        const balanceOfReceiverContractToken2 = await token2.balanceOf(receiverContract.address);
+        expect(balanceOfReceiverContractToken2).to.be.equal(0);
+        const balanceAggregatorToken1 = await token1.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken1).to.be.equal(0)
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
+
+        await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+
+
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(token2Amount);
+        const receiverContractToken1Balance = await token1.balanceOf(receiverContract.address);
+        expect(receiverContractToken1Balance).to.be.equal(0);
+        const aggregatorToken1Balance = await token1.balanceOf(aggregator.address);
+        expect(aggregatorToken1Balance).to.be.equal(token1Amount);
+        const aggregatorToken2Balance = await token2.balanceOf(aggregator.address);
+        expect(aggregatorToken2Balance).to.be.equal(0);
+    })
+    it("Swap usdt to tokens through delegate call", async () => {
+        const { usdt, token2, aggregator, user, receiverContract, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
+
+        const usdtAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await usdt.mint(receiverContract.address, usdtAmount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const balanceOfReceiverContractUSDT = await usdt.balanceOf(receiverContract.address);
+        expect(balanceOfReceiverContractUSDT).to.be.equal(usdtAmount);
+        const balanceAggregatorToken2 = await token2.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken2).to.be.equal(token2Amount);
+        const balanceOfReceiverContractToken2 = await token2.balanceOf(receiverContract.address);
+        expect(balanceOfReceiverContractToken2).to.be.equal(0);
+        const balanceAggregatorUSDT = await usdt.balanceOf(aggregator.address);
+        expect(balanceAggregatorUSDT).to.be.equal(0)
+
+        const swapData = await aggregator.populateTransaction.swap(usdt.address, token2.address, usdtAmount, token2Amount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(usdt.address, token2.address, aggregator.address, swapData.data || "", usdtAmount, token2Amount, receiverContract.address, false)
+
+        await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+
+
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(token2Amount);
+        const receiverContractUSDTBalance = await usdt.balanceOf(receiverContract.address);
+        expect(receiverContractUSDTBalance).to.be.equal(0);
+        const aggregatorUSDTBalance = await usdt.balanceOf(aggregator.address);
+        expect(aggregatorUSDTBalance).to.be.equal(usdtAmount);
+        const aggregatorToken2Balance = await token2.balanceOf(aggregator.address);
+        expect(aggregatorToken2Balance).to.be.equal(0);
+    })
+    it("Swap tokens to tokens through delegate call different receiver", async () => {
+        const { token1, token2, aggregator, user, receiverContract, metaAggregatorTestSwapContract, receiver } = await loadFixture(setupTest);
+
+        const token1Amount = 100000000;
+        const token2Amount = 100000000;
+
+        await token1.mint(receiverContract.address, token1Amount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const balanceOfReceiverContractToken1 = await token1.balanceOf(receiverContract.address);
+        expect(balanceOfReceiverContractToken1).to.be.equal(token1Amount);
+        const balanceAggregatorToken2 = await token2.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken2).to.be.equal(token2Amount);
+        const balanceReceiverToken2 = await token2.balanceOf(receiver.address);
+        expect(balanceReceiverToken2).to.be.equal(0);
+        const balanceOfReceiverContractToken2 = await token2.balanceOf(receiverContract.address);
+        expect(balanceOfReceiverContractToken2).to.be.equal(0);
+        const balanceAggregatorToken1 = await token1.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken1).to.be.equal(0)
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiver.address, false)
+
+        await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+
+
+        const receiverToken2Balance = await token2.balanceOf(receiver.address)
+        expect(receiverToken2Balance).to.be.equal(token2Amount);
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(0);
+        const receiverContractToken1Balance = await token1.balanceOf(receiverContract.address);
+        expect(receiverContractToken1Balance).to.be.equal(0);
         const aggregatorToken1Balance = await token1.balanceOf(aggregator.address);
         expect(aggregatorToken1Balance).to.be.equal(token1Amount);
         const aggregatorToken2Balance = await token2.balanceOf(aggregator.address);
@@ -79,10 +227,92 @@ describe("Swap test", function () {
         expect(userToken2Balance).to.be.equal(token2Amount);
         const ethBalanceOfAggregatorAfterSwap = await ethers.provider.getBalance(aggregator.address);
         expect(Number(ethBalanceOfAggregatorAfterSwap.sub(ethBalanceOfAggregator))).to.be.equal(nativeTokenAmount);
-
     })
+    it("Swap ETH to token through delegate call", async () => {
+        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, receiverContract } = await loadFixture(setupTest);
 
 
+        const nativeTokenAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await token2.mint(aggregator.address, token2Amount);
+
+        const ethBalanceUser = await ethers.provider.getBalance(user.address);
+        const balanceAggregatorToken2 = await token2.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken2).to.be.equal(token2Amount);
+        const ethBalanceOfAggregator = await ethers.provider.getBalance(aggregator.address);
+        expect(ethBalanceOfAggregator).to.be.equal(0);
+
+
+        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)
+
+
+
+        const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })
+        await tnx.wait();
+
+        const tnxReceipt = await ethers.provider.getTransactionReceipt(tnx.hash);
+
+
+        if (tnxReceipt?.cumulativeGasUsed && tnxReceipt?.effectiveGasPrice) {
+            const tnxGasCost = BigNumber(tnxReceipt?.cumulativeGasUsed.toString()).multipliedBy(tnxReceipt?.effectiveGasPrice.toString()).toFixed(0)
+            const ethBalanceUserAfterSwap = await ethers.provider.getBalance(user.address);
+            expect(Number(BigNumber(ethBalanceUser.toString()).minus(BigNumber(ethBalanceUserAfterSwap.toString())).minus(tnxGasCost).toFixed(0))).to.be.equal(nativeTokenAmount)
+        }
+
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(token2Amount);
+        const ethBalanceOfAggregatorAfterSwap = await ethers.provider.getBalance(aggregator.address);
+        expect(Number(ethBalanceOfAggregatorAfterSwap.sub(ethBalanceOfAggregator))).to.be.equal(nativeTokenAmount);
+    })
+    it("Swap ETH to token through delegate call different receiver", async () => {
+        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, receiverContract, receiver } = await loadFixture(setupTest);
+
+
+        const nativeTokenAmount = 100000000;
+        const token2Amount = 100000000;
+
+
+
+
+        await token2.mint(aggregator.address, token2Amount);
+
+        const ethBalanceUser = await ethers.provider.getBalance(user.address);
+        const balanceAggregatorToken2 = await token2.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken2).to.be.equal(token2Amount);
+        const balanceReceiverToken2 = await token2.balanceOf(receiver.address);
+        expect(balanceReceiverToken2).to.be.equal(0);
+        const ethBalanceOfAggregator = await ethers.provider.getBalance(aggregator.address);
+        expect(ethBalanceOfAggregator).to.be.equal(0);
+
+
+        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiver.address, false)
+
+
+
+        const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })
+        await tnx.wait();
+
+        const tnxReceipt = await ethers.provider.getTransactionReceipt(tnx.hash);
+
+
+        if (tnxReceipt?.cumulativeGasUsed && tnxReceipt?.effectiveGasPrice) {
+            const tnxGasCost = BigNumber(tnxReceipt?.cumulativeGasUsed.toString()).multipliedBy(tnxReceipt?.effectiveGasPrice.toString()).toFixed(0)
+            const ethBalanceUserAfterSwap = await ethers.provider.getBalance(user.address);
+            expect(Number(BigNumber(ethBalanceUser.toString()).minus(BigNumber(ethBalanceUserAfterSwap.toString())).minus(tnxGasCost).toFixed(0))).to.be.equal(nativeTokenAmount)
+        }
+
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(0);
+        const receiverToken2Balance = await token2.balanceOf(receiver.address)
+        expect(receiverToken2Balance).to.be.equal(token2Amount);
+        const ethBalanceOfAggregatorAfterSwap = await ethers.provider.getBalance(aggregator.address);
+        expect(Number(ethBalanceOfAggregatorAfterSwap.sub(ethBalanceOfAggregator))).to.be.equal(nativeTokenAmount);
+    })
     it("Swap token to ETH", async () => {
         const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user } = await loadFixture(setupTest);
 
@@ -91,7 +321,6 @@ describe("Swap test", function () {
         const nativeTokenAmount = 100000000;
 
 
-       
 
         const tx = await executor.sendTransaction({
             to: aggregator.address,
@@ -139,7 +368,91 @@ describe("Swap test", function () {
         const aggregatorToken1Balance = await token1.balanceOf(aggregator.address)
         expect(aggregatorToken1Balance).to.be.equal(token1Amount);
     })
+    it("Swap token to ETH through delegate call", async () => {
+        const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
+
+        const token1Amount = 100000000;
+        const nativeTokenAmount = 100000000;
+
+
+
+        const tx = await executor.sendTransaction({
+            to: aggregator.address,
+            value: nativeTokenAmount
+        });
+
+
+        await token1.mint(receiverContract.address, token1Amount);
+
+        const balanceReceiverContractToken1 = await token1.balanceOf(receiverContract.address);
+        expect(balanceReceiverContractToken1).to.be.equal(token1Amount);
+        const ethBalanceOfAggregator = await ethers.provider.getBalance(aggregator.address);
+        expect(ethBalanceOfAggregator).to.be.equal(nativeTokenAmount);
+        const balanceAggregatorToken1 = await token1.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken1).to.be.equal(0)
+        const ethBalanceReceiverContract = await ethers.provider.getBalance(receiverContract.address);
+        expect(ethBalanceReceiverContract).to.be.equal(0)
+
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverContract.address, false)
+
+        const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+        await tnx.wait();
+
+        const ethBalanceReceiverContractAfterSwap = await ethers.provider.getBalance(receiverContract.address);
+        expect(ethBalanceReceiverContractAfterSwap).to.be.equal(nativeTokenAmount)
+        const aggregatorToken1Balance = await token1.balanceOf(aggregator.address)
+        expect(aggregatorToken1Balance).to.be.equal(token1Amount);
+    })
+    it("Swap token to ETH through delegate call different receiver", async () => {
+        const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract, metaAggregatorTestSwapContract, receiver } = await loadFixture(setupTest);
+
+
+        const token1Amount = 100000000;
+        const nativeTokenAmount = 100000000;
+
+
+
+        const tx = await executor.sendTransaction({
+            to: aggregator.address,
+            value: nativeTokenAmount
+        });
+
+
+        await token1.mint(receiverContract.address, token1Amount);
+
+        const balanceReceiverContractToken1 = await token1.balanceOf(receiverContract.address);
+        expect(balanceReceiverContractToken1).to.be.equal(token1Amount);
+        const ethBalanceOfAggregator = await ethers.provider.getBalance(aggregator.address);
+        expect(ethBalanceOfAggregator).to.be.equal(nativeTokenAmount);
+        const balanceAggregatorToken1 = await token1.balanceOf(aggregator.address);
+        expect(balanceAggregatorToken1).to.be.equal(0)
+        const ethBalanceReceiverContract = await ethers.provider.getBalance(receiverContract.address);
+        expect(ethBalanceReceiverContract).to.be.equal(0)
+        const ethBalanceReceiver = await ethers.provider.getBalance(receiver.address);
+
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiver.address, false)
+
+        const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+        await tnx.wait();
+
+        const ethBalanceReceiverContractAfterSwap = await ethers.provider.getBalance(receiverContract.address);
+        expect(ethBalanceReceiverContractAfterSwap).to.be.equal(0)
+        const ethBalanceReceiverAfterSwap = await ethers.provider.getBalance(receiver.address);
+        expect(Number((
+            (BigNumber(ethBalanceReceiverAfterSwap.toString())
+            ).minus(BigNumber(ethBalanceReceiver.toString())).toFixed(0)))).to.be.equal(nativeTokenAmount)
+        const aggregatorToken1Balance = await token1.balanceOf(aggregator.address)
+        expect(aggregatorToken1Balance).to.be.equal(token1Amount);
+    })
     it("Swap token to ETH receiver is contract", async () => {
         const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract } = await loadFixture(setupTest);
 
@@ -148,7 +461,7 @@ describe("Swap test", function () {
         const nativeTokenAmount = 100000000;
 
 
-       executor.sendTransaction({
+        executor.sendTransaction({
             to: aggregator.address,
             value: nativeTokenAmount
         });
@@ -182,7 +495,6 @@ describe("Swap test", function () {
         const aggregatorToken1Balance = await token1.balanceOf(aggregator.address)
         expect(aggregatorToken1Balance).to.be.equal(token1Amount);
     })
-
     it("Swap token to token Enso Aggregator", async () => {
         const { token1, token2, ensoAggregator, metaAggregatorTestManager, user, receiver, ensoHelper } = await loadFixture(setupTest);
 
@@ -218,8 +530,84 @@ describe("Swap test", function () {
         expect(receiverToken1Balance).to.be.equal(token1Amount);
         const ensoHelperToken2Balance = await token2.balanceOf(ensoHelper.address);
         expect(ensoHelperToken2Balance).to.be.equal(0);
+    })
+    it("Swap token to token Enso Aggregator through delegate call", async () => {
+        const { token1, token2, ensoAggregator, metaAggregatorTestManager, user, receiverContract, metaAggregatorTestSwapContract, ensoHelper } = await loadFixture(setupTest);
 
 
+        const token1Amount = 100000000;
+        const token2Amount = 100000000;
+
+        await token1.mint(receiverContract.address, token1Amount);
+        await token2.mint(ensoHelper.address, token2Amount);
+
+        const balanceReceiverContractToken1 = await token1.balanceOf(receiverContract.address);
+        expect(balanceReceiverContractToken1).to.be.equal(token1Amount);
+        const balanceEnsoHelperToken2 = await token2.balanceOf(ensoHelper.address);
+        expect(balanceEnsoHelperToken2).to.be.equal(token2Amount);
+        const balanceUserToken2 = await token2.balanceOf(user.address);
+        expect(balanceUserToken2).to.be.equal(0);
+        const balanceEnsoHelperToken1 = await token1.balanceOf(ensoHelper.address);
+        expect(balanceEnsoHelperToken1).to.be.equal(0)
+
+
+        const swapData = await ensoAggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount, ensoHelper.address);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, ensoAggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, true)
+
+        await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+
+
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(token2Amount);
+        const receiverContractToken1Balance = await token1.balanceOf(receiverContract.address);
+        expect(receiverContractToken1Balance).to.be.equal(0);
+        const EnsoHelperToken1Balance = await token1.balanceOf(ensoHelper.address);
+        expect(EnsoHelperToken1Balance).to.be.equal(token1Amount);
+        const ensoHelperToken2Balance = await token2.balanceOf(ensoHelper.address);
+        expect(ensoHelperToken2Balance).to.be.equal(0);
+    })
+    it("Swap token to token Enso Aggregator through delegate call different receiver", async () => {
+        const { token1, token2, ensoAggregator, metaAggregatorTestManager, user, receiverContract, metaAggregatorTestSwapContract, ensoHelper, receiver } = await loadFixture(setupTest);
+
+
+        const token1Amount = 100000000;
+        const token2Amount = 100000000;
+
+        await token1.mint(receiverContract.address, token1Amount);
+        await token2.mint(ensoHelper.address, token2Amount);
+
+        const balanceReceiverContractToken1 = await token1.balanceOf(receiverContract.address);
+        expect(balanceReceiverContractToken1).to.be.equal(token1Amount);
+        const balanceReceiverToken1 = await token1.balanceOf(receiver.address);
+        expect(balanceReceiverToken1).to.be.equal(0);
+        const balanceEnsoHelperToken2 = await token2.balanceOf(ensoHelper.address);
+        expect(balanceEnsoHelperToken2).to.be.equal(token2Amount);
+        const balanceUserToken2 = await token2.balanceOf(user.address);
+        expect(balanceUserToken2).to.be.equal(0);
+        const balanceEnsoHelperToken1 = await token1.balanceOf(ensoHelper.address);
+        expect(balanceEnsoHelperToken1).to.be.equal(0)
+
+
+        const swapData = await ensoAggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount, ensoHelper.address);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, ensoAggregator.address, swapData.data || "", token1Amount, token2Amount, receiver.address, true)
+
+        await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+
+
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(0);
+        const receiverToken2Balance = await token2.balanceOf(receiver.address)
+        expect(receiverToken2Balance).to.be.equal(token2Amount);
+        const receiverContractToken1Balance = await token1.balanceOf(receiverContract.address);
+        expect(receiverContractToken1Balance).to.be.equal(0);
+        const EnsoHelperToken1Balance = await token1.balanceOf(ensoHelper.address);
+        expect(EnsoHelperToken1Balance).to.be.equal(token1Amount);
+        const ensoHelperToken2Balance = await token2.balanceOf(ensoHelper.address);
+        expect(ensoHelperToken2Balance).to.be.equal(0);
     })
     it("Swap ETh to token Enso Aggregator", async () => {
         const { token2, ensoAggregator, metaAggregatorTestSwapContract, nativeToken, user, receiver, ensoHelper } = await loadFixture(setupTest);
@@ -258,8 +646,91 @@ describe("Swap test", function () {
         const ethBalanceOfReceiverAfterSwap = await ethers.provider.getBalance(receiver.address);
         expect(ethBalanceOfReceiverAfterSwap.sub(ethBalanceOfReceiver)).to.be.equal(nativeTokenAmount);
     })
+    it("Swap ETh to token Enso Aggregator through delegate call", async () => {
+        const { token2, ensoAggregator, nativeToken, user, receiverContract, metaAggregatorTestSwapContract, ensoHelper } = await loadFixture(setupTest);
 
 
+        const nativeTokenAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await token2.mint(ensoHelper.address, token2Amount);
+
+        const ethBalanceUser = await ethers.provider.getBalance(user.address);
+
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(0);
+        const balanceEnsoHelperToken2 = await token2.balanceOf(ensoHelper.address);
+        expect(balanceEnsoHelperToken2).to.be.equal(token2Amount);
+        const ethBalanceOfEnsoHelper = await ethers.provider.getBalance(ensoHelper.address);
+        expect(ethBalanceOfEnsoHelper).to.be.equal(0)
+
+        const swapData = await ensoAggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount, ensoHelper.address);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, ensoAggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, true)
+
+        const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })
+        await tnx.wait();
+
+        const tnxReceipt = await ethers.provider.getTransactionReceipt(tnx.hash);
+
+
+        if (tnxReceipt?.cumulativeGasUsed && tnxReceipt?.effectiveGasPrice) {
+            const tnxGasCost = BigNumber(tnxReceipt?.cumulativeGasUsed.toString()).multipliedBy(tnxReceipt?.effectiveGasPrice.toString()).toFixed(0)
+            const ethBalanceUserAfterSwap = await ethers.provider.getBalance(user.address);
+            expect(Number(BigNumber(ethBalanceUser.toString()).minus(BigNumber(ethBalanceUserAfterSwap.toString())).minus(tnxGasCost).toFixed(0))).to.be.equal(nativeTokenAmount)
+        }
+
+
+        const receiverContractToken2BalanceAfterSwap = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2BalanceAfterSwap).to.be.equal(token2Amount);
+        const ethBalanceOfEnsoHelperAfterSwap = await ethers.provider.getBalance(ensoHelper.address);
+        expect(ethBalanceOfEnsoHelperAfterSwap.sub(ethBalanceOfEnsoHelper)).to.be.equal(nativeTokenAmount);
+    })
+    it("Swap ETh to token Enso Aggregator through delegate call different receiver", async () => {
+        const { token2, ensoAggregator, nativeToken, user, receiverContract, metaAggregatorTestSwapContract, ensoHelper, receiver } = await loadFixture(setupTest);
+
+
+        const nativeTokenAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await token2.mint(ensoHelper.address, token2Amount);
+
+        const ethBalanceUser = await ethers.provider.getBalance(user.address);
+
+        const receiverContractToken2Balance = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2Balance).to.be.equal(0);
+        const receiverToken2Balance = await token2.balanceOf(receiver.address)
+        expect(receiverToken2Balance).to.be.equal(0);
+        const balanceEnsoHelperToken2 = await token2.balanceOf(ensoHelper.address);
+        expect(balanceEnsoHelperToken2).to.be.equal(token2Amount);
+        const ethBalanceOfEnsoHelper = await ethers.provider.getBalance(ensoHelper.address);
+        expect(ethBalanceOfEnsoHelper).to.be.equal(0)
+
+        const swapData = await ensoAggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount, ensoHelper.address);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, ensoAggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiver.address, true)
+
+        const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })
+        await tnx.wait();
+
+        const tnxReceipt = await ethers.provider.getTransactionReceipt(tnx.hash);
+
+
+        if (tnxReceipt?.cumulativeGasUsed && tnxReceipt?.effectiveGasPrice) {
+            const tnxGasCost = BigNumber(tnxReceipt?.cumulativeGasUsed.toString()).multipliedBy(tnxReceipt?.effectiveGasPrice.toString()).toFixed(0)
+            const ethBalanceUserAfterSwap = await ethers.provider.getBalance(user.address);
+            expect(Number(BigNumber(ethBalanceUser.toString()).minus(BigNumber(ethBalanceUserAfterSwap.toString())).minus(tnxGasCost).toFixed(0))).to.be.equal(nativeTokenAmount)
+        }
+
+        const receiverToken2BalanceAfterSwap = await token2.balanceOf(receiver.address)
+        expect(receiverToken2BalanceAfterSwap).to.be.equal(token2Amount);
+        const receiverContractToken2BalanceAfterSwap = await token2.balanceOf(receiverContract.address)
+        expect(receiverContractToken2BalanceAfterSwap).to.be.equal(0);
+        const ethBalanceOfEnsoHelperAfterSwap = await ethers.provider.getBalance(ensoHelper.address);
+        expect(ethBalanceOfEnsoHelperAfterSwap.sub(ethBalanceOfEnsoHelper)).to.be.equal(nativeTokenAmount);
+    })
     it("Swap token to ETH Enso Aggregator", async () => {
         const { token1, ensoAggregator, metaAggregatorTestManager, nativeToken, executor, user, receiver, ensoHelper } = await loadFixture(setupTest);
 
@@ -309,10 +780,95 @@ describe("Swap test", function () {
         const receiverToken1Balance = await token1.balanceOf(receiver.address)
         expect(receiverToken1Balance).to.be.equal(token1Amount);
     })
+    it("Swap token to ETH Enso Aggregator through delegate call", async () => {
+        const { token1, ensoAggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract, metaAggregatorTestSwapContract, ensoHelper } = await loadFixture(setupTest);
+
+
+        const token1Amount = 100000000;
+        const nativeTokenAmount = 100000000;
+
+
+        executor.sendTransaction({
+            to: ensoHelper.address,
+            value: nativeTokenAmount
+        });
+
+        await token1.mint(receiverContract.address, token1Amount);
+
+        const balanceReceiverContractToken1 = await token1.balanceOf(receiverContract.address);
+        expect(balanceReceiverContractToken1).to.be.equal(token1Amount);
+        const ethBalanceOfEnsoHelper = await ethers.provider.getBalance(ensoHelper.address);
+        expect(ethBalanceOfEnsoHelper).to.be.equal(nativeTokenAmount);
+        const ensoHelperToken1Balance = await token1.balanceOf(ensoHelper.address)
+        expect(ensoHelperToken1Balance).to.be.equal(0);
+        const ethBalanceReceiverContract = await ethers.provider.getBalance(receiverContract.address);
+        expect(ethBalanceReceiverContract).to.be.equal(0)
+
+
+        const swapData = await ensoAggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount, ensoHelper.address);
+
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, ensoAggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverContract.address, true)
+
+        await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+
+
+
+        const ensoHelperToken1BalanceAfterSwap = await token1.balanceOf(ensoHelper.address)
+        expect(ensoHelperToken1BalanceAfterSwap).to.be.equal(token1Amount);
+        const ethBalanceReceiverContractAfterSwap = await ethers.provider.getBalance(receiverContract.address);
+        expect(ethBalanceReceiverContractAfterSwap).to.be.equal(nativeTokenAmount)
+    })
+    it("Swap token to ETH Enso Aggregator through delegate call different receiver", async () => {
+        const { token1, ensoAggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract, metaAggregatorTestSwapContract, ensoHelper, receiver } = await loadFixture(setupTest);
+
+
+        const token1Amount = 100000000;
+        const nativeTokenAmount = 100000000;
+
+
+        executor.sendTransaction({
+            to: ensoHelper.address,
+            value: nativeTokenAmount
+        });
+
+        await token1.mint(receiverContract.address, token1Amount);
+
+        const balanceReceiverContractToken1 = await token1.balanceOf(receiverContract.address);
+        expect(balanceReceiverContractToken1).to.be.equal(token1Amount);
+        const ethBalanceOfEnsoHelper = await ethers.provider.getBalance(ensoHelper.address);
+        expect(ethBalanceOfEnsoHelper).to.be.equal(nativeTokenAmount);
+        const ensoHelperToken1Balance = await token1.balanceOf(ensoHelper.address)
+        expect(ensoHelperToken1Balance).to.be.equal(0);
+        const ethBalanceReceiverContract = await ethers.provider.getBalance(receiverContract.address);
+        expect(ethBalanceReceiverContract).to.be.equal(0)
+        const ethBalanceReceiver = await ethers.provider.getBalance(receiver.address);
+
+
+        const swapData = await ensoAggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount, ensoHelper.address);
+
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, ensoAggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiver.address, true)
+
+        await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
+
+
+
+        const ensoHelperToken1BalanceAfterSwap = await token1.balanceOf(ensoHelper.address)
+        expect(ensoHelperToken1BalanceAfterSwap).to.be.equal(token1Amount);
+        const ethBalanceReceiverContractAfterSwap = await ethers.provider.getBalance(receiverContract.address);
+        expect(ethBalanceReceiverContractAfterSwap).to.be.equal(0)
+        const ethBalanceReceiverAfterSwap = await ethers.provider.getBalance(receiver.address);
+        expect(Number((
+            (BigNumber(ethBalanceReceiverAfterSwap.toString())
+            ).minus(BigNumber(ethBalanceReceiver.toString())).toFixed(0)))).to.be.equal(nativeTokenAmount)
+    })
 });
 
 describe("Coverage test", async () => {
-    it("should fail if the user has not approved the manager to swap their tokens", async () => {
+    it("should revert if the user has not approved the manager to swap their tokens", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -326,7 +882,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, token2.address, aggregator.address, swapData.data || "" || "", token1Amount, token2Amount, user.address, false)).to.be.revertedWithCustomError(metaAggregatorTestManager, "TransferFromFailed")
     })
-    it("should fail if the user doesn't have token to swap", async () => {
+    it("should revert if the user doesn't have token to swap", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -340,7 +896,7 @@ describe("Coverage test", async () => {
         await tnx.wait();
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, token2.address, aggregator.address, swapData.data || "" || "", token1Amount, token2Amount, user.address, false)).to.revertedWithCustomError(metaAggregatorTestManager, "TransferFromFailed")
     })
-    it("should fail if for re-entrancy call to swap manager contract", async () => {
+    it("should revert if for re-entrancy call to swap manager contract", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user, nonReentrantTest, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -359,7 +915,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, token2.address, nonReentrantTest.address, reEntrantData.data || " ", token1Amount, token2Amount, user.address, false)).to.revertedWith("ReentrancyGuard: reentrant call")
     })
-    it("should fail if ETH to token was tried to swap on manager contract", async () => {
+    it("should revert if ETH to token was tried to swap on manager contract", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user, nativeToken } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -375,8 +931,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(nativeToken, token2.address, aggregator.address, swapData.data || "" || "", token1Amount, token2Amount, user.address, false)).to.be.revertedWithCustomError(metaAggregatorTestManager, "CannotSwapETH")
     })
-
-    it("should fail when token fail swapping tokens using swapETH method", async () => {
+    it("should revert when swapping tokens using swapETH method", async () => {
         const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, token1 } = await loadFixture(setupTest);
 
 
@@ -389,9 +944,8 @@ describe("Coverage test", async () => {
         const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(token1.address, token2.address, aggregator.address, swapData.data || "" || "", nativeTokenAmount, token2Amount, user.address, false, { value: nativeTokenAmount })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "CannotSwapTokens")
-
     })
-    it("should fail when the minAmountOut is zero", async () => {
+    it("should revert when the minAmountOut is zero", async () => {
         const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user } = await loadFixture(setupTest);
 
 
@@ -405,7 +959,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "" || "", nativeTokenAmount, 0, user.address, false, { value: nativeTokenAmount })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "MinAmountOutMustBeGreaterThanZero")
     })
-    it("should fail when amount in is zero", async () => {
+    it("should revert when amount in is zero", async () => {
         const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user } = await loadFixture(setupTest);
 
 
@@ -419,7 +973,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "" || "", 0, token2Amount, user.address, false, { value: nativeTokenAmount })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "AmountInMustBeGreaterThanZero")
     })
-    it("should fail when same token are tried to swap", async () => {
+    it("should revert when same token are tried to swap", async () => {
         const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user } = await loadFixture(setupTest);
 
 
@@ -433,7 +987,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(nativeToken, nativeToken, aggregator.address, swapData.data || "" || "", nativeTokenAmount, token2Amount, user.address, false, { value: nativeTokenAmount })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "TokenInAndTokenOutCannotBeSame")
     })
-    it("should fail when tokens swapped are same swapERC20", async () => {
+    it("should revert when tokens swapped are same swapERC20", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -450,7 +1004,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, token1.address, aggregator.address, swapData.data || "" || "", token1Amount, token2Amount, user.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "TokenInAndTokenOutCannotBeSame")
     })
-    it("should fail when amount out is zero for swapERC20", async () => {
+    it("should revert when amount out is zero for swapERC20", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -466,7 +1020,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, token2.address, aggregator.address, swapData.data || "" || "", token1Amount, 0, user.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "MinAmountOutMustBeGreaterThanZero")
     })
-    it("should fail when amount in is zero for swapERC20", async () => {
+    it("should revert when amount in is zero for swapERC20", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -482,7 +1036,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, token2.address, aggregator.address, swapData.data || "" || "", 0, token2Amount, user.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "AmountInMustBeGreaterThanZero")
     })
-    it("should fail when incorrect ETH amount is sent in swapETh", async () => {
+    it("should revert when incorrect ETH amount is sent in swapETh", async () => {
         const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user } = await loadFixture(setupTest);
 
 
@@ -496,7 +1050,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, user.address, false, { value: 0 })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "IncorrectEtherAmountSent")
     })
-    it("should fail when token amount swapped is not sufficient through swapETh method", async () => {
+    it("should revert when token amount swapped is not sufficient through swapETh method", async () => {
         const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user } = await loadFixture(setupTest);
 
 
@@ -510,7 +1064,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, user.address, false, { value: nativeTokenAmount })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "InsufficientOutputBalance")
     })
-    it("should fail when tokens swapped out amount is not enough through swapERC20", async () => {
+    it("should revert when tokens swapped out amount is not enough through swapERC20", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -527,8 +1081,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, user.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "InsufficientTokenOutAmount")
     })
-
-    it("should fail when ETH swapped out amount is not enough through swapERC20", async () => {
+    it("should revert when ETH swapped out amount is not enough through swapERC20", async () => {
         const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
 
@@ -553,8 +1106,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, user.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "InsufficientETHOutAmount")
     })
-
-    it("should fail when re-entrancy attack if performed on swapERC20 method", async () => {
+    it("should revert when re-entrancy attack if performed on swapERC20 method", async () => {
         const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, metaAggregatorTestSwapContract, nonReentrantTest } = await loadFixture(setupTest);
 
 
@@ -577,7 +1129,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, nativeToken, nonReentrantTest.address, reEntrantData.data || "", token1Amount, nativeTokenAmount, user.address, false)).to.be.revertedWith("ReentrancyGuard: reentrant call")
     })
-    it("should fail when re-entrancy attack is made on swapETH method", async () => {
+    it("should revert when re-entrancy attack is made on swapETH method", async () => {
         const { token2, ensoAggregator, metaAggregatorTestSwapContract, nativeToken, user, receiver, ensoHelper, nonReentrantTest } = await loadFixture(setupTest);
 
 
@@ -596,7 +1148,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(nativeToken, token2.address, nonReentrantTest.address, reEntrantData.data || "", nativeTokenAmount, token2Amount, user.address, false, { value: nativeTokenAmount })).to.be.revertedWith("ReentrancyGuard: reentrant call")
     })
-    it("should fail when call to enso fails", async () => {
+    it("should revert when call to enso fails", async () => {
         const { token2, ensoAggregator, metaAggregatorTestSwapContract, nativeToken, user, ensoHelper } = await loadFixture(setupTest);
 
 
@@ -610,8 +1162,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(nativeToken, token2.address, ensoAggregator.address, swapData.data || "" || "", nativeTokenAmount, token2Amount, user.address, true, { value: nativeTokenAmount })).to.be.reverted
     })
-
-    it("should fail if the receiver contract reverts on receive Eth", async () => {
+    it("should revert if the receiver contract reverts on receive Eth", async () => {
         const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract, receiverRevert } = await loadFixture(setupTest);
 
 
@@ -636,7 +1187,7 @@ describe("Coverage test", async () => {
 
         await expect(receiverContract.connect(user).swap(metaAggregatorTestManager.address, token1.address, nativeToken, aggregator.address, swapData.data || "" || "", token1Amount, nativeTokenAmount, receiverRevert.address, false)).to.be.reverted
     })
-    it("should fail when receiver is zero address token to token swap", async () => {
+    it("should revert when receiver is zero address token to token swap", async () => {
         const { token1, token2, aggregator, metaAggregatorTestManager, user, metaAggregatorTestSwapContract, zeroAddress } = await loadFixture(setupTest);
 
         const token1Amount = 100000000;
@@ -652,7 +1203,7 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestManager.connect(user).swap(token1.address, token2.address, aggregator.address, swapData.data || "" || "", token1Amount, token2Amount, zeroAddress, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "InvalidReceiver")
     })
-    it("should fail when receiver address is zero ETH to token swap", async () => {
+    it("should revert when receiver address is zero ETH to token swap", async () => {
         const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, zeroAddress } = await loadFixture(setupTest);
 
 
@@ -666,27 +1217,193 @@ describe("Coverage test", async () => {
 
         await expect(metaAggregatorTestSwapContract.connect(user).swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "" || "", nativeTokenAmount, token2Amount, zeroAddress, false, { value: nativeTokenAmount })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "InvalidReceiver")
     })
-
     it("should revert when deploying manager with invalid swap contract address", async () => {
         const { zeroAddress } = await loadFixture(setupTest);
         const MetaAggregatorManager = await ethers.getContractFactory("MetaAggregatorManager");
         await expect(MetaAggregatorManager.deploy(zeroAddress)).to.be.reverted;
-
     })
-    it("should fail when deploying swap contract with invalid enso aggregator contract", async () => {
+    it("should revert when deploying swap contract with invalid enso aggregator contract", async () => {
         const { zeroAddress, usdt } = await loadFixture(setupTest);
 
         const MetaAggregatorTestSwapContract = await ethers.getContractFactory("MetaAggregatorSwapContract");
 
-        await expect(MetaAggregatorTestSwapContract.deploy(zeroAddress, usdt)).to.be.reverted;
+        await expect(MetaAggregatorTestSwapContract.deploy(zeroAddress, usdt.address)).to.be.reverted;
 
     })
-    it("should fail when deploying swap contract with invalid usdt contract", async () => {
+    it("should revert when deploying swap contract with invalid usdt contract", async () => {
         const { ensoAggregator, zeroAddress } = await loadFixture(setupTest);
 
         const MetaAggregatorTestSwapContract = await ethers.getContractFactory("MetaAggregatorSwapContract");
 
-        await expect(MetaAggregatorTestSwapContract.deploy(ensoAggregator.address,zeroAddress)).to.be.reverted;
+        await expect(MetaAggregatorTestSwapContract.deploy(ensoAggregator.address, zeroAddress)).to.be.reverted;
+    })
+    it("should revert when when EOA calls erc20Delegate function", async () => {
+        const { token1, token2, aggregator, metaAggregatorTestManager, user, receiverContract, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
+        const token1Amount = 100000000;
+        const token2Amount = 100000000;
+
+        await token1.mint(receiverContract.address, token1Amount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
+
+        await expect(metaAggregatorTestSwapContract.connect(user).swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, 'NotDelegate')
+    })
+    it("should revert when when EOA calls ethDelegate function", async () => {
+        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, receiverContract } = await loadFixture(setupTest);
+
+
+        const nativeTokenAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
+
+        await expect(metaAggregatorTestSwapContract.connect(user).swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, 'NotDelegate')
+    })
+    it("should revert when native token is swapped through swap erc20 delegate function", async () => {
+        const { token1, token2, aggregator, user, receiverContract, metaAggregatorTestSwapContract, nativeToken } = await loadFixture(setupTest);
+
+        const token1Amount = 100000000;
+        const token2Amount = 100000000;
+
+        await token1.mint(receiverContract.address, token1Amount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(nativeToken, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
+
+        await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
+    })
+    it("should revert when tokens are swapped through swap eth delegate function", async () => {
+        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, receiverContract } = await loadFixture(setupTest);
+
+
+        const nativeTokenAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await token2.mint(aggregator.address, token2Amount);
+
+        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(token2.address, nativeToken, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)
+        await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })).to.be.reverted
+    })
+    it("should revert when eth value sent is not equal to amount in swap eth delegate call", async () => {
+        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, receiverContract } = await loadFixture(setupTest);
+
+
+        const nativeTokenAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await token2.mint(aggregator.address, token2Amount);
+
+        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount / 2, token2Amount, receiverContract.address, false)
+
+
+
+        await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })).to.be.reverted
+    })
+    it("should revert when amount out is not equal to min amount out in swap eth delegate call", async () => {
+        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, receiverContract } = await loadFixture(setupTest);
+
+
+        const nativeTokenAmount = 100000000;
+        const token2Amount = 100000000;
+
+        await token2.mint(aggregator.address, token2Amount);
+
+        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount * 2, receiverContract.address, false)
+
+
+
+        await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })).to.be.reverted
+    })
+    it("should revert when token balance is not equal to amountIn for swap erc20 delegate function", async () => {
+        const { token1, token2, aggregator, user, receiverContract, metaAggregatorTestSwapContract, nativeToken } = await loadFixture(setupTest);
+
+        const token1Amount = 100000000;
+        const token2Amount = 100000000;
+
+        await token1.mint(receiverContract.address, token1Amount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, 2 * token1Amount, token2Amount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
+
+        await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
+    })
+    it("should revert when token swapped out are not equal to min amount out for swap erc20 delegate function", async () => {
+        const { token1, token2, aggregator, user, receiverContract, metaAggregatorTestSwapContract, nativeToken } = await loadFixture(setupTest);
+
+        const token1Amount = 100000000;
+        const token2Amount = 100000000;
+
+        await token1.mint(receiverContract.address, token1Amount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount * 2, receiverContract.address, false)
+
+        await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
+    })
+    it("should revert when ETH swapped out are not equal to min amount out for swap erc20 delegate function", async () => {
+        const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
+
+        const token1Amount = 100000000;
+        const nativeTokenAmount = 100000000;
+
+        const tx = await executor.sendTransaction({
+            to: aggregator.address,
+            value: nativeTokenAmount
+        });
+
+        await token1.mint(receiverContract.address, token1Amount);
+
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, 2*nativeTokenAmount, receiverContract.address, false)
+
+         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
+    })
+    it("should revert when ETH swapped out fails for swap erc20 delegate function", async () => {
+        const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract, metaAggregatorTestSwapContract, receiverRevert } = await loadFixture(setupTest);
+
+        const token1Amount = 100000000;
+        const nativeTokenAmount = 100000000;
+
+        const tx = await executor.sendTransaction({
+            to: aggregator.address,
+            value: nativeTokenAmount
+        });
+
+        await token1.mint(receiverContract.address, token1Amount);
+
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
+
+
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverRevert.address, false)
+
+        await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
     })
 })

--- a/test/meta-aggregator-test/meta-aggregator.test.ts
+++ b/test/meta-aggregator-test/meta-aggregator.test.ts
@@ -1381,9 +1381,9 @@ describe("Coverage test", async () => {
         const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, 2*nativeTokenAmount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, 2 * nativeTokenAmount, receiverContract.address, false)
 
-         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
+        await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
     })
     it("should revert when ETH swapped out fails for swap erc20 delegate function", async () => {
         const { token1, aggregator, metaAggregatorTestManager, nativeToken, executor, user, receiverContract, metaAggregatorTestSwapContract, receiverRevert } = await loadFixture(setupTest);

--- a/test/meta-aggregator-test/meta-aggregator.test.ts
+++ b/test/meta-aggregator-test/meta-aggregator.test.ts
@@ -101,7 +101,7 @@ describe("Swap test", function () {
         const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
 
         await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
 
@@ -137,7 +137,7 @@ describe("Swap test", function () {
         const swapData = await aggregator.populateTransaction.swap(usdt.address, token2.address, usdtAmount, token2Amount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(usdt.address, token2.address, aggregator.address, swapData.data || "", usdtAmount, token2Amount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(usdt.address, token2.address, aggregator.address, swapData.data || "", usdtAmount, token2Amount, receiverContract.address, false)
 
         await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
 
@@ -175,7 +175,7 @@ describe("Swap test", function () {
         const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiver.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiver.address, false)
 
         await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
 
@@ -246,7 +246,7 @@ describe("Swap test", function () {
 
         const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)
 
 
 
@@ -290,7 +290,7 @@ describe("Swap test", function () {
 
         const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiver.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiver.address, false)
 
 
 
@@ -398,7 +398,7 @@ describe("Swap test", function () {
         const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverContract.address, false)
 
         const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
         await tnx.wait();
@@ -439,7 +439,7 @@ describe("Swap test", function () {
         const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiver.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiver.address, false)
 
         const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
         await tnx.wait();
@@ -554,7 +554,7 @@ describe("Swap test", function () {
         const swapData = await ensoAggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount, ensoHelper.address);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, ensoAggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, true)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, token2.address, ensoAggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, true)
 
         await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
 
@@ -593,7 +593,7 @@ describe("Swap test", function () {
         const swapData = await ensoAggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount, ensoHelper.address);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, ensoAggregator.address, swapData.data || "", token1Amount, token2Amount, receiver.address, true)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, token2.address, ensoAggregator.address, swapData.data || "", token1Amount, token2Amount, receiver.address, true)
 
         await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
 
@@ -667,7 +667,7 @@ describe("Swap test", function () {
         const swapData = await ensoAggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount, ensoHelper.address);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, ensoAggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, true)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(nativeToken, token2.address, ensoAggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, true)
 
         const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })
         await tnx.wait();
@@ -710,7 +710,7 @@ describe("Swap test", function () {
         const swapData = await ensoAggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount, ensoHelper.address);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, ensoAggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiver.address, true)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(nativeToken, token2.address, ensoAggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiver.address, true)
 
         const tnx = await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })
         await tnx.wait();
@@ -809,7 +809,7 @@ describe("Swap test", function () {
 
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, ensoAggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverContract.address, true)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, nativeToken, ensoAggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverContract.address, true)
 
         await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
 
@@ -850,7 +850,7 @@ describe("Swap test", function () {
 
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, ensoAggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiver.address, true)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, nativeToken, ensoAggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiver.address, true)
 
         await receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")
 
@@ -1237,34 +1237,7 @@ describe("Coverage test", async () => {
 
         await expect(MetaAggregatorTestSwapContract.deploy(ensoAggregator.address, zeroAddress)).to.be.reverted;
     })
-    it("should revert when when EOA calls erc20Delegate function", async () => {
-        const { token1, token2, aggregator, metaAggregatorTestManager, user, receiverContract, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
 
-        const token1Amount = 100000000;
-        const token2Amount = 100000000;
-
-        await token1.mint(receiverContract.address, token1Amount);
-        await token2.mint(aggregator.address, token2Amount);
-
-
-        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
-
-        await expect(metaAggregatorTestSwapContract.connect(user).swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, 'NotDelegate')
-    })
-    it("should revert when when EOA calls ethDelegate function", async () => {
-        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, receiverContract } = await loadFixture(setupTest);
-
-
-        const nativeTokenAmount = 100000000;
-        const token2Amount = 100000000;
-
-        await token2.mint(aggregator.address, token2Amount);
-
-
-        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
-
-        await expect(metaAggregatorTestSwapContract.connect(user).swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, 'NotDelegate')
-    })
     it("should revert when native token is swapped through swap erc20 delegate function", async () => {
         const { token1, token2, aggregator, user, receiverContract, metaAggregatorTestSwapContract, nativeToken } = await loadFixture(setupTest);
 
@@ -1278,7 +1251,7 @@ describe("Coverage test", async () => {
         const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(nativeToken, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(nativeToken, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
 
         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
     })
@@ -1293,7 +1266,7 @@ describe("Coverage test", async () => {
 
         const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(token2.address, nativeToken, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(token2.address, nativeToken, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)
         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })).to.be.reverted
     })
     it("should revert when eth value sent is not equal to amount in swap eth delegate call", async () => {
@@ -1307,7 +1280,7 @@ describe("Coverage test", async () => {
 
         const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount / 2, token2Amount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount / 2, token2Amount, receiverContract.address, false)
 
 
 
@@ -1324,7 +1297,7 @@ describe("Coverage test", async () => {
 
         const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETHDelegate(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount * 2, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount * 2, receiverContract.address, false)
 
 
 
@@ -1343,7 +1316,7 @@ describe("Coverage test", async () => {
         const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, 2 * token1Amount, token2Amount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount, receiverContract.address, false)
 
         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
     })
@@ -1360,7 +1333,7 @@ describe("Coverage test", async () => {
         const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount * 2, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, token2.address, aggregator.address, swapData.data || "", token1Amount, token2Amount * 2, receiverContract.address, false)
 
         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
     })
@@ -1381,7 +1354,7 @@ describe("Coverage test", async () => {
         const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, 2 * nativeTokenAmount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, 2 * nativeTokenAmount, receiverContract.address, false)
 
         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
     })
@@ -1402,7 +1375,7 @@ describe("Coverage test", async () => {
         const swapData = await aggregator.populateTransaction.swap(token1.address, nativeToken, token1Amount, nativeTokenAmount);
 
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20Delegate(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverRevert.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapERC20(token1.address, nativeToken, aggregator.address, swapData.data || "", token1Amount, nativeTokenAmount, receiverRevert.address, false)
 
         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
     })

--- a/test/meta-aggregator-test/meta-aggregator.test.ts
+++ b/test/meta-aggregator-test/meta-aggregator.test.ts
@@ -1269,7 +1269,7 @@ describe("Coverage test", async () => {
         const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(token2.address, nativeToken, aggregator.address, swapData.data || "", nativeTokenAmount, token2Amount, receiverContract.address, false)
         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ", { value: nativeTokenAmount })).to.be.reverted
     })
-    it("should revert when eth value sent is not equal to amount in swap eth delegate call", async () => {
+    it("should revert when eth value sent is smaller to amount in swap eth delegate call", async () => {
         const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, receiverContract } = await loadFixture(setupTest);
 
 
@@ -1280,7 +1280,7 @@ describe("Coverage test", async () => {
 
         const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, nativeTokenAmount, token2Amount);
 
-        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount / 2, token2Amount, receiverContract.address, false)
+        const delegateSwapData = await metaAggregatorTestSwapContract.populateTransaction.swapETH(nativeToken, token2.address, aggregator.address, swapData.data || "", nativeTokenAmount * 2, token2Amount, receiverContract.address, false)
 
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,10 +2702,10 @@ axios@^0.27.2:
     follow-redirects "^1.14.9"
     form-data "^4.0.0"
 
-axios@^1.4.0, axios@^1.5.1:
-  version "1.7.2"
-  resolved "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz"
-  integrity sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==
+axios@^1.4.0, axios@^1.5.1, axios@^1.7.9:
+  version "1.7.9"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz"
+  integrity sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==
   dependencies:
     follow-redirects "^1.15.6"
     form-data "^4.0.0"


### PR DESCRIPTION
The following method are made for contract to swap using meta-aggregator swap contract. 

1. swapETHDelegate: This method can be used by contracts to swap ETH to tokens
2. swapERC20Delegate: This method can be used by contracts to swap tokens. The contract don't need to give apporval for its swap.  