### PR TITLE
Added fee deduction to meta-aggregator

### DIFF
--- a/contracts/meta-aggregator/MetaAggregatorSwapContract.sol
+++ b/contracts/meta-aggregator/MetaAggregatorSwapContract.sol
@@ -33,6 +33,9 @@ contract MetaAggregatorSwapContract is IMetaAggregatorSwapContract {
     error InsufficientTokenOutAmount();
     error SwapFailed();
     error CannotSwapETH();
+    error InvalidTargetsCalldataLength();
+    error TargetCallFailed();
+    error InvalidTargetsValuesLength();
 
     //   Event emitted when ETH is swapped for an ERC20 token
     event ETHSwappedForToken(
@@ -50,7 +53,7 @@ contract MetaAggregatorSwapContract is IMetaAggregatorSwapContract {
     );
 
     /**
-     * @dev Initializes the contract with the swap target and USDT addresses.
+     * @dev Initializes the contract with the swap target and USDT targets.
      * @param _ensoSwapContract The address of the swap target contract.
      * @param _usdt The address of the USDT token.
      */
@@ -100,181 +103,150 @@ contract MetaAggregatorSwapContract is IMetaAggregatorSwapContract {
         }
     }
 
-    /**
-     * @dev Swaps ETH for an ERC20 token.
-     * @param tokenIn must be the native token.
-     * @param tokenOut The ERC20 token to swap to.
-     * @param aggregator The address of the aggregator to use for the swap.
-     * @param swapData The data required for the swap.
-     * @param amountIn The amount of ETH to swap.
-     * @param minAmountOut The minimum amount of tokenOut expected.
-     * @param receiver The address to receive the tokenOut.
-     * @param isDelegate Indicates if the swap is in a delegatecall context.
-     */
+    /// @notice Executes a token swap using the MetaAggregatorSwap contract
+    /// @param params The parameters required for the swap, encapsulated in the SwapETHParams struct
+    /// @dev This function checks if the input token is the native token (ETH) and reverts if so.
     function swapETH(
-        address tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
+        SwapETHParams calldata params
     ) external payable nonReentrant {
-        if (address(tokenIn) != nativeToken) {
+        if (address(params.tokenIn) != nativeToken) {
             revert CannotSwapTokens();
         }
-        uint256 amountOut = _swapETH(
-            tokenIn,
-            tokenOut,
-            aggregator,
-            swapData,
-            amountIn,
-            minAmountOut,
-            receiver,
-            isDelegate
+        uint256 amountOut = _swapETH(params);
+        emit ETHSwappedForToken(
+            amountOut,
+            address(params.tokenOut),
+            params.receiver
         );
+    }
+
+    /// @notice Executes a token swap using the MetaAggregatorSwap contract
+    /// @param params The parameters required for the swap, encapsulated in the SwapERC20Params struct
+    /// @dev This function checks if the input token is the native token (ETH) and reverts if so.
+    function swapERC20(SwapERC20Params calldata params) external nonReentrant {
+        uint256 amountOut = _swapERC20(params);
         emit ERC20Swapped(
             amountOut,
-            address(tokenIn),
-            address(tokenOut),
-            receiver
+            address(params.tokenIn),
+            address(params.tokenOut),
+            params.receiver
         );
     }
 
-    /**
-     * @dev Swaps one ERC20 token for another ERC20 token or native ETH.
-     * @param tokenIn The ERC20 token to swap from.
-     * @param tokenOut The ERC20 token to swap to or native ETH.
-     * @param aggregator The address of the aggregator to use for the swap.
-     * @param swapData The data required for the swap.
-     * @param amountIn The amount of tokenIn to swap.
-     * @param minAmountOut The minimum amount of tokenOut expected.
-     * @param receiver The address to receive the tokenOut.
-     * @param isDelegate Indicates if the swap is in a delegatecall context.
-     */
-    function swapERC20(
-        IERC20 tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
-    ) external nonReentrant {
-        uint256 amountOut = _swapERC20(
-            tokenIn,
-            tokenOut,
-            aggregator,
-            swapData,
-            amountIn,
-            minAmountOut,
-            receiver,
-            isDelegate
-        );
-        emit ETHSwappedForToken(amountOut, address(tokenOut), receiver);
-    }
-
-    /**
-     * @dev Internal function to perform the swap from ETH to ERC20.
-     * @param tokenIn must be the native token.
-     * @param tokenOut The ERC20 token to swap to.
-     * @param aggregator The address of the aggregator to use for the swap.
-     * @param swapData The data required for the swap.
-     * @param amountIn The amount of ETH to swap.
-     * @param minAmountOut The minimum amount of tokenOut expected.
-     * @param receiver The address to receive the tokenOut.
-     * @param isDelegate Indicates if the swap is in a delegatecall context.
-     * @return The amount of tokenOut received.
-     */
     function _swapETH(
-        address tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
+        SwapETHParams calldata params
     ) internal returns (uint256) {
         _validateInputs(
-            tokenIn,
-            address(tokenOut),
-            amountIn,
-            minAmountOut,
-            receiver
+            params.tokenIn,
+            address(params.tokenOut),
+            params.amountIn,
+            params.minAmountOut,
+            params.receiver
         );
 
-        if (msg.value < amountIn) revert IncorrectEtherAmountSent();
+        if(params.targets.length != params.values.length) revert InvalidTargetsValuesLength();
 
-        uint256 balanceBefore = tokenOut.balanceOf(address(this));
-        _executeAggregatorCall(swapData, isDelegate, aggregator, amountIn);
-        uint256 amountOut = tokenOut.balanceOf(address(this)) - balanceBefore;
+        {
+            for (uint256 i = 0; i < params.targets.length; i++) {
+                (bool success, ) = params.targets[i].call{
+                    value: params.values[i]
+                }("");
+                if (!success) revert SwapFailed();
+            }
+        }
 
-        if (amountOut < minAmountOut) revert InsufficientOutputBalance();
-        if (receiver != address(this)) {
-            TransferHelper.safeTransfer(address(tokenOut), receiver, amountOut);
+        if (msg.value < params.amountIn) revert IncorrectEtherAmountSent();
+
+        uint256 balanceBefore = params.tokenOut.balanceOf(address(this));
+        _executeAggregatorCall(
+            params.swapData,
+            params.isDelegate,
+            params.aggregator,
+            params.amountIn
+        );
+        uint256 amountOut = params.tokenOut.balanceOf(address(this)) -
+            balanceBefore;
+
+        if (amountOut < params.minAmountOut) revert InsufficientOutputBalance();
+        if (params.receiver != address(this)) {
+            TransferHelper.safeTransfer(
+                address(params.tokenOut),
+                params.receiver,
+                amountOut
+            );
         }
         return amountOut;
     }
 
-    /**
-     * @dev Internal function to swap ERC20 tokens or ERC20 to native ETH.
-     * @param tokenIn The ERC20 token to swap from.
-     * @param tokenOut The ERC20 token to swap to or native ETH.
-     * @param aggregator The address of the aggregator to use for the swap.
-     * @param swapData The data required for the swap.
-     * @param amountIn The amount of tokenIn to swap.
-     * @param minAmountOut The minimum amount of tokenOut expected.
-     * @param receiver The address to receive the tokenOut.
-     * @param isDelegate Indicates if the swap is in a delegatecall context.
-     * @return The amount of tokenOut received.
-     */
     function _swapERC20(
-        IERC20 tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
+        SwapERC20Params calldata params
     ) internal returns (uint256) {
         _validateInputs(
-            address(tokenIn),
-            address(tokenOut),
-            amountIn,
-            minAmountOut,
-            receiver
+            address(params.tokenIn),
+            address(params.tokenOut),
+            params.amountIn,
+            params.minAmountOut,
+            params.receiver
         );
 
-        if (!isDelegate) {
-            if (address(tokenIn) == usdt)
-                TransferHelper.safeApprove(address(tokenIn), aggregator, 0);
-            TransferHelper.safeApprove(address(tokenIn), aggregator, amountIn);
+        if(params.targets.length != params.calldataArray.length) revert InvalidTargetsCalldataLength();
+        {
+            for (uint256 i = 0; i < params.targets.length; i++) {
+                (bool success, ) = params.targets[i].call(
+                    params.calldataArray[i]
+                );
+                if (!success) revert SwapFailed();
+            }
+        }
+
+        if (!params.isDelegate) {
+            if (address(params.tokenIn) == usdt)
+                TransferHelper.safeApprove(
+                    address(params.tokenIn),
+                    params.aggregator,
+                    0
+                );
+            TransferHelper.safeApprove(
+                address(params.tokenIn),
+                params.aggregator,
+                params.amountIn
+            );
         }
 
         uint256 amountOut;
-        if (address(tokenOut) == nativeToken) {
+        if (address(params.tokenOut) == nativeToken) {
             uint256 balanceBefore = address(this).balance;
-            _executeAggregatorCall(swapData, isDelegate, aggregator, 0);
+            _executeAggregatorCall(
+                params.swapData,
+                params.isDelegate,
+                params.aggregator,
+                0
+            );
             amountOut = address(this).balance - balanceBefore;
-            if (amountOut < minAmountOut) revert InsufficientETHOutAmount();
-            if (receiver != address(this)) {
-                (bool success, ) = receiver.call{value: amountOut}("");
+            if (amountOut < params.minAmountOut)
+                revert InsufficientETHOutAmount();
+            if (params.receiver != address(this)) {
+                (bool success, ) = params.receiver.call{value: amountOut}("");
                 if (!success) revert SwapFailed();
             }
         } else {
-            uint256 balanceBefore = tokenOut.balanceOf(address(this));
-            _executeAggregatorCall(swapData, isDelegate, aggregator, 0);
-            amountOut = tokenOut.balanceOf(address(this)) - balanceBefore;
-            if (amountOut < minAmountOut) revert InsufficientTokenOutAmount();
+            uint256 balanceBefore = params.tokenOut.balanceOf(address(this));
+            _executeAggregatorCall(
+                params.swapData,
+                params.isDelegate,
+                params.aggregator,
+                0
+            );
+            amountOut =
+                params.tokenOut.balanceOf(address(this)) -
+                balanceBefore;
+            if (amountOut < params.minAmountOut)
+                revert InsufficientTokenOutAmount();
 
-            if (receiver != address(this)) {
+            if (params.receiver != address(this)) {
                 TransferHelper.safeTransfer(
-                    address(tokenOut),
-                    receiver,
+                    address(params.tokenOut),
+                    params.receiver,
                     amountOut
                 );
             }

--- a/contracts/meta-aggregator/interfaces/IMetaAggregatorManager.sol
+++ b/contracts/meta-aggregator/interfaces/IMetaAggregatorManager.sol
@@ -2,16 +2,31 @@
 pragma solidity 0.8.17;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-
 interface IMetaAggregatorManager {
-    function swap(
-        IERC20 tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
-    ) external;
+    
+    /// @notice Struct to hold parameters for the ERC20 swap operation
+    /// @param tokenIn The ERC20 token to swap from
+    /// @param tokenOut The ERC20 token to swap to
+    /// @param aggregator The address of the aggregator to use for the swap
+    /// @param swapData Additional data required for the swap
+    /// @param amountIn The amount of tokenIn to swap
+    /// @param minAmountOut The minimum amount of tokenOut expected from the swap
+    /// @param receiver The address that will receive the tokenOut
+    /// @param isDelegate Indicates if the swap is being executed by a delegate
+    /// @param targets Array of addresses to call during the swap for fees
+    /// @param calldataArray Array of calldata for each target for fees
+    struct SwapERC20Params {
+        IERC20 tokenIn;
+        IERC20 tokenOut;
+        address aggregator;
+        bytes swapData;
+        uint256 amountIn;
+        uint256 minAmountOut;
+        address receiver;
+        bool isDelegate;
+        address[] targets;
+        bytes[] calldataArray;
+    }
+
+    function swap(SwapERC20Params calldata params) external;
 }

--- a/contracts/meta-aggregator/interfaces/IMetaAggregatorSwapContract.sol
+++ b/contracts/meta-aggregator/interfaces/IMetaAggregatorSwapContract.sol
@@ -2,27 +2,58 @@
 pragma solidity 0.8.17;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-
 interface IMetaAggregatorSwapContract {
-    function swapERC20(
-        IERC20 tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
-    ) external;
 
-    function swapETH(
-        address tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
-    ) external payable;
+    /// @notice Struct to hold parameters for the ETH swap operation
+    /// @param tokenIn The ETH token to swap from
+    /// @param tokenOut The ERC20 token to swap to
+    /// @param aggregator The address of the aggregator to use for the swap
+    /// @param swapData Additional data required for the swap
+    /// @param amountIn The amount of tokenIn to swap
+    /// @param minAmountOut The minimum amount of tokenOut expected from the swap
+    /// @param receiver The address that will receive the tokenOut
+    /// @param isDelegate Indicates if the swap is being executed by a delegate
+    /// @param targets Array of addresses to call during the swap for fees
+    /// @param values Array of values for each target for fees
+    struct SwapETHParams {
+        address tokenIn;
+        IERC20 tokenOut;
+        address aggregator;
+        bytes swapData;
+        uint256 amountIn;
+        uint256 minAmountOut;
+        address receiver;
+        bool isDelegate;
+        address[] targets;
+        uint256[] values;
+    }
+
+        
+    /// @notice Struct to hold parameters for the ERC20 swap operation
+    /// @param tokenIn The ERC20 token to swap from
+    /// @param tokenOut The ERC20 token to swap to
+    /// @param aggregator The address of the aggregator to use for the swap
+    /// @param swapData Additional data required for the swap
+    /// @param amountIn The amount of tokenIn to swap
+    /// @param minAmountOut The minimum amount of tokenOut expected from the swap
+    /// @param receiver The address that will receive the tokenOut
+    /// @param isDelegate Indicates if the swap is being executed by a delegate
+    /// @param targets Array of addresses to call during the swap for fees
+    /// @param calldataArray Array of calldata for each target for fees
+    struct SwapERC20Params {
+        IERC20 tokenIn;
+        IERC20 tokenOut;
+        address aggregator;
+        bytes swapData;
+        uint256 amountIn;
+        uint256 minAmountOut;
+        address receiver;
+        bool isDelegate;
+        address[] targets;
+        bytes[] calldataArray;
+    }
+
+    function swapERC20(SwapERC20Params calldata params) external;
+
+    function swapETH(SwapETHParams calldata params) external payable;
 }

--- a/contracts/meta-aggregator/test/MetaAggregatorTestManager.sol
+++ b/contracts/meta-aggregator/test/MetaAggregatorTestManager.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.17;
-
-import {MetaAggregatorManager} from "../MetaAggregatorManager.sol";
-
-contract MetaAggregatorTestManager is MetaAggregatorManager {
-    constructor(address _metaAggregatorTestSwap) MetaAggregatorManager(_metaAggregatorTestSwap){}
-}

--- a/contracts/meta-aggregator/test/NonReentrantTest.sol
+++ b/contracts/meta-aggregator/test/NonReentrantTest.sol
@@ -6,70 +6,22 @@ import "../interfaces/IMetaAggregatorSwapContract.sol";
 contract NonReentrantTest {
     function receiveCall(
         address callerAddress,
-        IERC20 tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
+        IMetaAggregatorManager.SwapERC20Params calldata params
     ) external payable {
-        IMetaAggregatorManager(callerAddress).swap(
-            tokenIn,
-            tokenOut,
-            aggregator,
-            swapData,
-            amountIn,
-            minAmountOut,
-            receiver,
-            isDelegate
-        );
+        IMetaAggregatorManager(callerAddress).swap(params);
     }
 
     function receiverCallETH(
         address callerAddress,
-        address tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
+        IMetaAggregatorSwapContract.SwapETHParams calldata params
     ) external payable {
-        IMetaAggregatorSwapContract(callerAddress).swapETH(
-            tokenIn,
-            tokenOut,
-            aggregator,
-            swapData,
-            amountIn,
-            minAmountOut,
-            receiver,
-            isDelegate
-        );
+        IMetaAggregatorSwapContract(callerAddress).swapETH(params);
     }
 
     function receiverCallToken(
         address callerAddress,
-        IERC20 tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
+        IMetaAggregatorSwapContract.SwapERC20Params calldata params
     ) external payable {
-        IMetaAggregatorSwapContract(callerAddress).swapERC20(
-            tokenIn,
-            tokenOut,
-            aggregator,
-            swapData,
-            amountIn,
-            minAmountOut,
-            receiver,
-            isDelegate
-        );
+        IMetaAggregatorSwapContract(callerAddress).swapERC20(params);
     }
 }

--- a/contracts/meta-aggregator/test/ReceiverContract.sol
+++ b/contracts/meta-aggregator/test/ReceiverContract.sol
@@ -21,35 +21,12 @@ contract ReceiverContract {
         IERC20(token).approve(spender, amount);
     }
 
-    /**
-     * @dev Calls the swap function in the TestManagerContract.
-     * @param testManager The address of the TestManagerContract.
-     * @param tokenIn The address of the input token.
-     * @param tokenOut The address of the output token.
-     * @param amountIn The amount of input tokens to swap.
-     * @param minAmountOut The minimum amount of output tokens expected.
-     */
+
     function swap(
         address testManager,
-        IERC20 tokenIn,
-        IERC20 tokenOut,
-        address aggregator,
-        bytes calldata swapData,
-        uint256 amountIn,
-        uint256 minAmountOut,
-        address receiver,
-        bool isDelegate
+        IMetaAggregatorManager.SwapERC20Params calldata params
     ) external {
-        IMetaAggregatorManager(testManager).swap(
-            tokenIn,
-            tokenOut,
-            aggregator,
-            swapData,
-            amountIn,
-            minAmountOut,
-            receiver,
-            isDelegate
-        );
+        IMetaAggregatorManager(testManager).swap(params);
     }
 
     /**

--- a/test/meta-aggregator-test/fixture.ts
+++ b/test/meta-aggregator-test/fixture.ts
@@ -3,8 +3,7 @@ import { ethers } from "hardhat";
 
 // test setup
 export const setupTest = async () => {
-    const [deployer, executor, user, receiver] = await ethers.getSigners(); // Get signers
-
+    const [deployer, executor, user, receiver, feeReceiver1, feeReceiver2] = await ethers.getSigners(); // Get signers
 
     // Deploy Token1
     const Token1 = await ethers.getContractFactory("TESTERC20");
@@ -82,6 +81,8 @@ export const setupTest = async () => {
         receiverContract,
         receiverRevert,
         zeroAddress,
-        usdt
+        usdt,
+        feeReceiver1,
+        feeReceiver2
     };
 };

--- a/test/meta-aggregator-test/meta-aggregator.test.ts
+++ b/test/meta-aggregator-test/meta-aggregator.test.ts
@@ -64,8 +64,8 @@ describe("Swap test", function () {
         const token1Amount = "594675716556465465156456456";
         const token2Amount = 100000000;
 
-        const {amountAfterFee, fee} = calculateFee(token1Amount, feePercentage)
-        const {feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount} = divideFee(fee, feeReceiver1Percentage)
+        const { amountAfterFee, fee } = calculateFee(token1Amount, feePercentage)
+        const { feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount } = divideFee(fee, feeReceiver1Percentage)
 
 
 
@@ -226,8 +226,8 @@ describe("Swap test", function () {
         const token1Amount = "594675716556465465156456456";
         const token2Amount = 100000000;
 
-        const {amountAfterFee, fee} = calculateFee(token1Amount, feePercentage)
-        const {feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount} = divideFee(fee, feeReceiver1Percentage)
+        const { amountAfterFee, fee } = calculateFee(token1Amount, feePercentage)
+        const { feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount } = divideFee(fee, feeReceiver1Percentage)
 
         await token1.mint(receiverContract.address, token1Amount);
         await token2.mint(aggregator.address, token2Amount);
@@ -421,7 +421,7 @@ describe("Swap test", function () {
             values: []
         };
 
-        const tnx = await metaAggregatorTestSwapContract.connect(user).swapETH(swapETHParams, {value: nativeTokenAmount})
+        const tnx = await metaAggregatorTestSwapContract.connect(user).swapETH(swapETHParams, { value: nativeTokenAmount })
 
         await tnx.wait();
 
@@ -448,8 +448,8 @@ describe("Swap test", function () {
         const nativeTokenAmount = "59467571655646";
         const token2Amount = 100000000;
 
-        const {amountAfterFee, fee} = calculateFee(nativeTokenAmount, feePercentage)
-        const {feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount} = divideFee(fee, feeReceiver1Percentage)
+        const { amountAfterFee, fee } = calculateFee(nativeTokenAmount, feePercentage)
+        const { feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount } = divideFee(fee, feeReceiver1Percentage)
 
         await token2.mint(aggregator.address, token2Amount);
 
@@ -478,7 +478,7 @@ describe("Swap test", function () {
             values: [feeReceiver1Amount, feeReceiver2Amount]
         };
 
-        const tnx = await metaAggregatorTestSwapContract.connect(user).swapETH(swapETHParams, {value: nativeTokenAmount})
+        const tnx = await metaAggregatorTestSwapContract.connect(user).swapETH(swapETHParams, { value: nativeTokenAmount })
 
         await tnx.wait();
 
@@ -562,8 +562,8 @@ describe("Swap test", function () {
         const nativeTokenAmount = "59467571655646";
         const token2Amount = 100000000;
 
-        const {amountAfterFee, fee} = calculateFee(nativeTokenAmount, feePercentage)
-        const {feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount} = divideFee(fee, feeReceiver1Percentage)
+        const { amountAfterFee, fee } = calculateFee(nativeTokenAmount, feePercentage)
+        const { feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount } = divideFee(fee, feeReceiver1Percentage)
         await token2.mint(aggregator.address, token2Amount);
 
         const ethBalanceUser = await ethers.provider.getBalance(user.address);
@@ -1089,7 +1089,7 @@ describe("Swap test", function () {
             values: []
         }
 
-        const tnx = await metaAggregatorTestSwapContract.connect(user).swapETH(swapNativeParams, {value: nativeTokenAmount})
+        const tnx = await metaAggregatorTestSwapContract.connect(user).swapETH(swapNativeParams, { value: nativeTokenAmount })
 
 
         await tnx.wait();
@@ -1905,7 +1905,7 @@ describe("Coverage test", async () => {
         }
 
 
-        const reEntrantData = await nonReentrantTest.populateTransaction.receiverCallETH(metaAggregatorTestSwapContract.address,swapParams);
+        const reEntrantData = await nonReentrantTest.populateTransaction.receiverCallETH(metaAggregatorTestSwapContract.address, swapParams);
 
         const swapParamsReEntrant = {
             tokenIn: nativeToken,
@@ -1981,7 +1981,7 @@ describe("Coverage test", async () => {
             isDelegate: false,
             targets: [],
             calldataArray: []
-        }           
+        }
         await expect(metaAggregatorTestManager.connect(user).swap(swapParams)).to.be.reverted
     })
     it("should revert when receiver is zero address token to token swap", async () => {
@@ -2102,9 +2102,9 @@ describe("Coverage test", async () => {
             tokenOut: nativeToken,
             aggregator: aggregator.address,
             swapData: swapData.data || "",
-            amountIn:nativeTokenAmount,
+            amountIn: nativeTokenAmount,
             minAmountOut: token2Amount,
-            receiver:receiverContract.address,
+            receiver: receiverContract.address,
             isDelegate: false,
             targets: [],
             values: []
@@ -2128,7 +2128,7 @@ describe("Coverage test", async () => {
             tokenOut: token2.address,
             aggregator: aggregator.address,
             swapData: swapData.data || "",
-            amountIn: nativeTokenAmount*2,
+            amountIn: nativeTokenAmount * 2,
             minAmountOut: token2Amount,
             receiver: receiverContract.address,
             isDelegate: false,
@@ -2158,7 +2158,7 @@ describe("Coverage test", async () => {
             aggregator: aggregator.address,
             swapData: swapData.data || "",
             amountIn: nativeTokenAmount,
-            minAmountOut: token2Amount*2,
+            minAmountOut: token2Amount * 2,
             receiver: receiverContract.address,
             isDelegate: false,
             targets: [],
@@ -2217,7 +2217,7 @@ describe("Coverage test", async () => {
             aggregator: aggregator.address,
             swapData: swapData.data || "",
             amountIn: token1Amount,
-            minAmountOut: token2Amount*2,
+            minAmountOut: token2Amount * 2,
             receiver: receiverContract.address,
             isDelegate: false,
             targets: [],
@@ -2292,27 +2292,26 @@ describe("Coverage test", async () => {
 
         await expect(receiverContract.connect(user).executeDelegate(metaAggregatorTestSwapContract.address, delegateSwapData.data || " ")).to.be.reverted
     })
-
-    it("Swap tokens to tokens", async () => {
-        const { token1, token2, aggregator, metaAggregatorTestManager, user } = await loadFixture(setupTest);
-
-        const token1Amount = 100000000;
+    it("should fail when fee is not equal to the sum of fee receiver amount", async () => {
+        const { token1, token2, aggregator, metaAggregatorTestManager, user, feeReceiver1, feeReceiver2, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
+        const feePercentage = 7.5
+        const feeReceiver1Percentage = 33.55;
+        const token1Amount = "594675716556465465156456456";
         const token2Amount = 100000000;
+
+        const { amountAfterFee, fee } = calculateFee(token1Amount, feePercentage)
+        const { feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount } = divideFee(fee, feeReceiver1Percentage)
+
+
 
         await token1.mint(user.address, token1Amount);
         await token2.mint(aggregator.address, token2Amount);
 
 
-        const balanceUserToken1 = await token1.balanceOf(user.address);
-        expect(balanceUserToken1).to.be.equal(token1Amount);
-        const balanceAggregatorToken2 = await token2.balanceOf(aggregator.address);
-        expect(balanceAggregatorToken2).to.be.equal(token2Amount);
-        const balanceUserToken2 = await token2.balanceOf(user.address);
-        expect(balanceUserToken2).to.be.equal(0);
-        const balanceAggregatorToken1 = await token1.balanceOf(aggregator.address);
-        expect(balanceAggregatorToken1).to.be.equal(0)
+        const feeTransferData1 = await token1.populateTransaction.transfer(feeReceiver1.address, feeReceiver1Amount)
+        const feeTransferData2 = await token1.populateTransaction.transfer(feeReceiver2.address, feeReceiver2Amount)
 
-        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, token1Amount, token2Amount);
+        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, amountAfterFee, token2Amount);
 
         const tnx = await token1.connect(user).approve(metaAggregatorTestManager.address, token1Amount)
         await tnx.wait();
@@ -2326,20 +2325,117 @@ describe("Coverage test", async () => {
             minAmountOut: token2Amount,
             receiver: user.address,
             isDelegate: false,
-            targets: [],
-            calldataArray: []
+            targets: [token1.address],
+            calldataArray: [feeTransferData1.data || "", feeTransferData2.data || ""]
         };
 
-        await metaAggregatorTestManager.connect(user).swap(swapETHParams)
+        await expect(metaAggregatorTestManager.connect(user).swap(swapETHParams)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "InvalidTargetsCalldataLength")
+    })
+
+    it("should fail when fee values are not equal to fee receivers", async () => {
+        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, feeReceiver1, feeReceiver2 } = await loadFixture(setupTest);
+
+        const feePercentage = 7.5
+        const feeReceiver1Percentage = 33.55;
+        const nativeTokenAmount = "59467571655646";
+        const token2Amount = 100000000;
+
+        const { amountAfterFee, fee } = calculateFee(nativeTokenAmount, feePercentage)
+        const { feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount } = divideFee(fee, feeReceiver1Percentage)
+
+        await token2.mint(aggregator.address, token2Amount);
 
 
-        const userToken2Balance = await token2.balanceOf(user.address)
-        expect(userToken2Balance).to.be.equal(token2Amount);
-        const userToken1Balance = await token1.balanceOf(user.address);
-        expect(userToken1Balance).to.be.equal(0);
-        const aggregatorToken1Balance = await token1.balanceOf(aggregator.address);
-        expect(aggregatorToken1Balance).to.be.equal(token1Amount);
-        const aggregatorToken2Balance = await token2.balanceOf(aggregator.address);
-        expect(aggregatorToken2Balance).to.be.equal(0);
+        expect(fee).to.be.equal(new BigNumber(feeReceiver1Amount).plus(new BigNumber(feeReceiver2Amount)).toFixed(0))
+
+        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, amountAfterFee, token2Amount);
+
+        const swapETHParams = {
+            tokenIn: nativeToken,
+            tokenOut: token2.address,
+            aggregator: aggregator.address,
+            swapData: swapData.data || "",
+            amountIn: nativeTokenAmount,
+            minAmountOut: token2Amount,
+            receiver: user.address,
+            isDelegate: false,
+            targets: [feeReceiver1.address],
+            values: [feeReceiver1Amount, feeReceiver2Amount]
+        };
+
+        await expect(metaAggregatorTestSwapContract.connect(user).swapETH(swapETHParams, { value: nativeTokenAmount })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "InvalidTargetsValuesLength")
+    })
+
+    it("should fail when fee in ERC20 transfer fails", async () => {
+        const { token1, token2, aggregator, metaAggregatorTestManager, user, feeReceiver1, feeReceiver2, metaAggregatorTestSwapContract } = await loadFixture(setupTest);
+        const feePercentage = 7.5
+        const feeReceiver1Percentage = 33.55;
+        const token1Amount = "594675716556465465156456456";
+        const token2Amount = 100000000;
+
+        const { amountAfterFee, fee } = calculateFee(token1Amount, feePercentage)
+        const { feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount } = divideFee(fee, feeReceiver1Percentage)
+
+
+
+        await token1.mint(user.address, token1Amount);
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        const feeTransferData1 = await token1.populateTransaction.transfer(feeReceiver1.address, BigInt(2 * Number(token1Amount)))
+        const feeTransferData2 = await token1.populateTransaction.transfer(feeReceiver2.address, feeReceiver2Amount)
+
+        const swapData = await aggregator.populateTransaction.swap(token1.address, token2.address, amountAfterFee, token2Amount);
+
+        const tnx = await token1.connect(user).approve(metaAggregatorTestManager.address, token1Amount)
+        await tnx.wait();
+
+        const swapETHParams = {
+            tokenIn: token1.address,
+            tokenOut: token2.address,
+            aggregator: aggregator.address,
+            swapData: swapData.data || "",
+            amountIn: token1Amount,
+            minAmountOut: token2Amount,
+            receiver: user.address,
+            isDelegate: false,
+            targets: [token1.address, token1.address],
+            calldataArray: [feeTransferData1.data || "", feeTransferData2.data || ""]
+        };
+
+        await expect(metaAggregatorTestManager.connect(user).swap(swapETHParams)).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "FeeTransferFailed")
+    })
+    it("should fail when fee transfer fails for native token", async () => {
+        const { token2, aggregator, metaAggregatorTestSwapContract, nativeToken, user, feeReceiver1, feeReceiver2 } = await loadFixture(setupTest);
+
+        const feePercentage = 7.5
+        const feeReceiver1Percentage = 33.55;
+        const nativeTokenAmount = "59467571655646";
+        const token2Amount = 100000000;
+
+        const { amountAfterFee, fee } = calculateFee(nativeTokenAmount, feePercentage)
+        const { feeReceiver1: feeReceiver1Amount, feeReceiver2: feeReceiver2Amount } = divideFee(fee, feeReceiver1Percentage)
+
+        await token2.mint(aggregator.address, token2Amount);
+
+
+        expect(fee).to.be.equal(new BigNumber(feeReceiver1Amount).plus(new BigNumber(feeReceiver2Amount)).toFixed(0))
+
+        const swapData = await aggregator.populateTransaction.swap(nativeToken, token2.address, amountAfterFee, token2Amount);
+
+        const swapETHParams = {
+            tokenIn: nativeToken,
+            tokenOut: token2.address,
+            aggregator: aggregator.address,
+            swapData: swapData.data || "",
+            amountIn: nativeTokenAmount,
+            minAmountOut: token2Amount,
+            receiver: user.address,
+            isDelegate: false,
+            targets: [feeReceiver1.address, feeReceiver2.address],
+            values: [2 * Number(nativeTokenAmount), feeReceiver2Amount]
+        };
+
+        await expect(metaAggregatorTestSwapContract.connect(user).swapETH(swapETHParams, { value: nativeTokenAmount })).to.be.revertedWithCustomError(metaAggregatorTestSwapContract, "FeeTransferFailed")
     })
 })

--- a/test/meta-aggregator-test/utils.ts
+++ b/test/meta-aggregator-test/utils.ts
@@ -1,0 +1,14 @@
+import BigNumber from "bignumber.js";
+
+export function calculateFee(amount: string, feePercentage: number): { amountAfterFee: string, fee: string } {
+    const fee = new BigNumber(amount).multipliedBy(new BigNumber(feePercentage)).dividedBy(100).toFixed(0);
+    const amountAfterFee = new BigNumber(amount).minus(fee).toFixed(0);
+    return {amountAfterFee, fee};
+}
+
+export function divideFee(feeAmount: string, feePercentageReceiver1: number): { feeReceiver1: string, feeReceiver2: string } {
+    const feeReceiver1 = new BigNumber(feeAmount).multipliedBy(new BigNumber(feePercentageReceiver1)).dividedBy(100).toFixed(0);
+    const feeReceiver2 = new BigNumber(feeAmount).multipliedBy(100 - feePercentageReceiver1).dividedBy(100).toFixed(0);
+    return {feeReceiver1, feeReceiver2};    
+}
+


### PR DESCRIPTION
Added  the following params: 

1. targets, calldata for erc20 swaps. These would be used to call the erc20 tokens to transfer the fee. They are arrays so we can add multiple fees. 
2. targets, value for eth swaps : They would similarly be use to transfer multiple fees in native tokens.  